### PR TITLE
Issue #26 - Support project references that contribute to tools folder

### DIFF
--- a/docs/Authoring.md
+++ b/docs/Authoring.md
@@ -165,7 +165,7 @@ Please note that the reference item doesn't support the `TargetFramework`
 metadata. Instead, NuGet will only add the references if the file is also
 packaged in the corresponding lib folder. If it's not the reference is simply
 ignored. In other words, the target framework is already controlled by the fact
-that the file might or might not be in the corr                 esponding lib folder.
+that the file might or might not be in the corresponding lib folder.
 
 ## Merging Nuspec Template
 

--- a/docs/Authoring.md
+++ b/docs/Authoring.md
@@ -90,49 +90,62 @@ As with dependencies, those can be specific to a certain target framework:
 
 ## Packaging Files
 
-Packaging library files is done as follows:
+Packaging files is done as follows:
 
 ```xml
 <ItemGroup>
-  <Library Include="$(BasePath)HelloWorld.dll" />
-    <TargetFramework>net40</TargetFramework>
-  </Library>
+  <!-- Package readme.txt nuproj folder. -->
+  <Content Include="readme.txt" />
+  <!-- Package all .css files in content\css directory. -->
+  <Content Include="content\css\**\*.css" />
+  <!-- You can also add library this way. -->
+  <Content Include="lib\net40\HelloWorld.dll" />
 </ItemGroup>
 ```
 
-The `TargetFramework` metadata is optional. If it's missing, the library will
-apply to all platforms. Please note that per convention the path to the file
-name is prefixed with the `$(BasePath)` property. This allows the build process
-to control where the binaries should be picked up from.
-
-For packaging content files you can use the `Content` item:
+The path of file is relative to NuProj project file. The files must be in 
+project directory or its subdirectory. You can include files outside project 
+directory by using `Link` metadata to specify file path in output package.
 
 ```xml
 <ItemGroup>
-  <!-- Package license.txt into content folder. -->
-  <Content Include="$(BasePath)license.txt" />
-  <!-- Package all .css files into content\css -->
-  <Content Include="$(BasePath)css\**\*.css">
-    <TargetPath>css</TargetPath>
-  </Content>
-  <!-- The following will also rename readme.txt to readme_HelloWorld.txt -->
-  <Content Include="$(BasePath)readme.txt">
-    <TargetPath>notes\readme_HelloWorld.txt</TargetPath>
+  <!-- Package icon.png. -->
+  <Content Include="..\common\icon.png">
+    <Link>icon.png</Link>
   </Content>
 </ItemGroup>
 ```
 
-The `Content` element supports an optional `TargetPath` metadata element. If not
-specified, the file will packaged directly into the content folder.
+## Using Project References
 
-For ultimate control, you can also use the File item which allows you to package
-arbitrary files:
+You can reference other projects to automatically include their output in 
+package. By default the project is considered to be a `Library` and will be
+put into `lib` folder. The package directory can be controlled by using 
+`PackageDirectory` metadata. Recognized values are: `Library`, `Tools`, `Build`,
+`Content` and `Root`. 
 
 ```xml
 <ItemGroup>
-  <File Include="$(BasePath)build.proj">
-    <TargetPath>tools\build</TargetPath>
-  </File>
+  <!-- Package output of Library.csproj to lib directory. -->
+  <ProjectReference Include="..\Library\Library.csproj" />
+  <!-- Package output of Tools.csproj to tools directory. -->
+  <ProjectReference Include="..\Tools\Tools.csproj">
+    <PackageDirectory>Tools</PackageDirectory>
+  </ProjectReference>
+  <!-- Package output of Tasks.csproj to build directory. -->
+  <ProjectReference Include="..\Tasks\Tasks.csproj">
+    <PackageDirectory>Build</PackageDirectory>
+  </ProjectReference>
+</ItemGroup>
+```
+
+You can also reference other NuProj projects to generate package dependencies.
+Dependency `Library` content will be removed from `Library` content of package.
+
+```xml
+<ItemGroup>
+  <!-- Add NuGet dependency. -->
+  <ProjectReference Include="..\Dependency\Dependency.nuproj" />
 </ItemGroup>
 ```
 
@@ -152,7 +165,7 @@ Please note that the reference item doesn't support the `TargetFramework`
 metadata. Instead, NuGet will only add the references if the file is also
 packaged in the corresponding lib folder. If it's not the reference is simply
 ignored. In other words, the target framework is already controlled by the fact
-that the file might or might not be in the corresponding lib folder.
+that the file might or might not be in the corr                 esponding lib folder.
 
 ## Merging Nuspec Template
 

--- a/docs/Authoring.md
+++ b/docs/Authoring.md
@@ -119,9 +119,9 @@ directory by using `Link` metadata to specify file path in output package.
 ## Using Project References
 
 You can reference other projects to automatically include their output in 
-package. By default the project is considered to be a `Library` and will be
+package. By default the project is considered to be a library and will be
 put into `lib` folder. The package directory can be controlled by using 
-`PackageDirectory` metadata. Recognized values are: `Library`, `Tools`, `Build`,
+`PackageDirectory` metadata. Recognized values are: `Lib`, `Tools`, `Build`,
 `Content` and `Root`. 
 
 ```xml
@@ -140,7 +140,9 @@ put into `lib` folder. The package directory can be controlled by using
 ```
 
 You can also reference other NuProj projects to generate package dependencies.
-Dependency `Library` content will be removed from `Library` content of package.
+Content of `Lib` directory of `Dependency` package will be removed from `Lib` 
+directory of dependent package. `Dependency` package will be added as a NuGet 
+dependency.
 
 ```xml
 <ItemGroup>

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -8,7 +8,7 @@ you need to override the `NuProjTargetsPath` property:
 
 ```xml
 <PropertyGroup>
-    <MyNuProjPath>$(MyCheckinRoot)packages\NuProj.0.9.2\tools\</MyNuProjPath>
+    <MyNuProjPath>$(MyCheckinRoot)packages\NuProj.0.9.3\tools\</MyNuProjPath>
     <NuProjTargetsPath>$(MyNuProjPath)NuProj.targets</NuProjTargetsPath>
     <!--
     <NuProjTasksPath>$(MyNuProjPath)NuProj.Tasks.dll</NuProjTasksPath>

--- a/src/Common/CommonAssemblyInfo.cs
+++ b/src/Common/CommonAssemblyInfo.cs
@@ -9,5 +9,5 @@
 [assembly : AssemblyMetadata("ProjectUrl", "http://nuproj.net")]
 [assembly : AssemblyMetadata("LicenseUrl", "http://nuproj.net/LICENSE")]
 
-[assembly: AssemblyVersion("0.9.2.0")]
-[assembly: AssemblyFileVersion("0.9.2.0")]
+[assembly: AssemblyVersion("0.9.3.0")]
+[assembly: AssemblyFileVersion("0.9.3.0")]

--- a/src/NuProj.Packages/NuProj.nuproj
+++ b/src/NuProj.Packages/NuProj.nuproj
@@ -24,13 +24,27 @@ There is also a Visual Studio which you find under http://bit.ly/NuProjVS.</Desc
   </PropertyGroup>
 
   <ItemGroup>
-    <Tool Include="$(BasePath)raw\NuProj.Tasks.dll" />
-    <Tool Include="$(BasePath)raw\Additional\NuProj.props" />
-    <Tool Include="$(BasePath)raw\Additional\NuProj.targets" />
-    <Tool Include="$(BasePath)raw\Additional\Microsoft.Common.NuProj.targets" />
-    <Tool Include="..\packages\NuGet.CommandLine.2.8.2\tools\NuGet.exe" />
-    <Tool Include="..\packages\NuGet.Core*\lib\net40-Client\NuGet.Core.dll" />
-    <Tool Include="..\packages\Microsoft.Web.Xdt*\lib\net40\Microsoft.Web.XmlTransform.dll" />
+    <Content Include="$(BasePath)raw\NuProj.Tasks.dll">
+      <Link>tools\NuProj.Tasks.dll</Link>
+    </Content>
+    <Content Include="$(BasePath)raw\Additional\NuProj.props">
+      <Link>tools\NuProj.props</Link>
+    </Content>
+    <Content Include="$(BasePath)raw\Additional\NuProj.targets">
+      <Link>tools\NuProj.targets</Link>
+    </Content>
+    <Content Include="$(BasePath)raw\Additional\Microsoft.Common.NuProj.targets">
+      <Link>tools\Microsoft.Common.NuProj.targets</Link>
+    </Content>
+    <Content Include="..\packages\NuGet.CommandLine.2.8.2\tools\NuGet.exe">
+      <Link>tools\NuGet.exe</Link>
+    </Content>
+    <Content Include="..\packages\NuGet.Core*\lib\net40-Client\NuGet.Core.dll">
+      <Link>tools\NuGet.Core.dll</Link>
+    </Content>
+    <Content Include="..\packages\Microsoft.Web.Xdt*\lib\net40\Microsoft.Web.XmlTransform.dll">
+      <Link>tools\Microsoft.Web.XmlTransform.dll</Link>
+    </Content>
   </ItemGroup>
 
   <Import Project="$(NuProjPath)\NuProj.targets" />

--- a/src/NuProj.Packages/NuProj.nuproj
+++ b/src/NuProj.Packages/NuProj.nuproj
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|AnyCPU">
+      <Configuration>Debug</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|AnyCPU">
+      <Configuration>Release</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
 
   <PropertyGroup>
     <NuProjPath Condition=" '$(NuProjPath)' == '' ">$(MSBuildExtensionsPath)\NuProj\</NuProjPath>
@@ -24,9 +34,12 @@ There is also a Visual Studio which you find under http://bit.ly/NuProjVS.</Desc
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="$(BasePath)raw\NuProj.Tasks.dll">
-      <Link>tools\NuProj.Tasks.dll</Link>
-    </Content>
+    <ProjectReference Include="..\NuProj.Tasks\NuProj.Tasks.csproj">
+      <PackageDirectory>Tools</PackageDirectory>
+    </ProjectReference>
+  </ItemGroup>
+  
+  <ItemGroup>
     <Content Include="$(BasePath)raw\Additional\NuProj.props">
       <Link>tools\NuProj.props</Link>
     </Content>
@@ -38,12 +51,6 @@ There is also a Visual Studio which you find under http://bit.ly/NuProjVS.</Desc
     </Content>
     <Content Include="..\packages\NuGet.CommandLine.2.8.5\tools\NuGet.exe">
       <Link>tools\NuGet.exe</Link>
-    </Content>
-    <Content Include="..\packages\NuGet.Core*\lib\net40-Client\NuGet.Core.dll">
-      <Link>tools\NuGet.Core.dll</Link>
-    </Content>
-    <Content Include="..\packages\Microsoft.Web.Xdt*\lib\net40\Microsoft.Web.XmlTransform.dll">
-      <Link>tools\Microsoft.Web.XmlTransform.dll</Link>
     </Content>
   </ItemGroup>
 

--- a/src/NuProj.Targets/NuProj.targets
+++ b/src/NuProj.Targets/NuProj.targets
@@ -107,7 +107,7 @@
   
   <ItemDefinitionGroup>
     <ProjectReference>
-      <PackageDirectory>Libraries</PackageDirectory>
+      <PackageDirectory>Lib</PackageDirectory>
       <TargetFramework></TargetFramework>
     </ProjectReference>
   </ItemDefinitionGroup>
@@ -353,7 +353,7 @@
                           Condition="'%(File.TargetPath)' == 'lib' OR
                                      $([System.String]::Copy('%(File.TargetPath)').ToLower().StartsWith('lib\')) OR
                                      $([System.String]::Copy('%(File.TargetPath)').ToLower().StartsWith('lib/'))">
-        <PackageDirectory>Libraries</PackageDirectory>
+        <PackageDirectory>Lib</PackageDirectory>
       </_FileWithIsLibrary>
       <_FileWithIsLibrary Include="@(File)"
                           Condition="'%(File.TargetPath)' != 'lib' AND
@@ -488,7 +488,7 @@
              Depending on referenced projects, single library can come from multiple locations,
              e.g target and intermediate output directories. -->
         <_RawLibraryTargetPath Include="@(File->'%(TargetPath)\%(FileName)%(Extension)')"
-                         Condition="'%(File.PackageDirectory)' == 'Libraries'">
+                         Condition="'%(File.PackageDirectory)' == 'Lib'">
             <OriginalItemSpec>%(File.Identity)</OriginalItemSpec>
         </_RawLibraryTargetPath>
       </ItemGroup>
@@ -516,7 +516,7 @@
         <_FileTargetPath Include="@(_FilteredLibraryTargetPath->'%(FileName)%(Extension)')" />
 
         <_FileTargetPath Include="@(File->'::KEEP::')"
-                         Condition="'%(File.PackageDirectory)' != 'Libraries'">
+                         Condition="'%(File.PackageDirectory)' != 'Lib'">
             <OriginalItemSpec>%(File.Identity)</OriginalItemSpec>
         </_FileTargetPath>
 
@@ -653,7 +653,7 @@
       
       <!-- Get files that are library and have assigned target framework (so no debug symbols files). -->
       <_DependencyFile Include="@(File)" 
-                       Condition="'%(File.PackageDirectory)' == 'Libraries' 
+                       Condition="'%(File.PackageDirectory)' == 'Lib' 
                          and '%(File.TargetFramework)' != '' 
                          and '%(File.NuProjPackageId)' == '%(NuProjDependency.Identity)'"/>
       
@@ -738,7 +738,7 @@
 
       <!-- Read each project's packages.config file. -->
       <ReadPackagesConfig Projects="@(_ProjectReferenceClosure)"
-                          Condition="'%(PackageDirectory)' == 'Libraries'">
+                          Condition="'%(PackageDirectory)' == 'Lib'">
         <Output TaskParameter="PackageReferences"
                 ItemName="_PackageReference" />
       </ReadPackagesConfig>

--- a/src/NuProj.Targets/NuProj.targets
+++ b/src/NuProj.Targets/NuProj.targets
@@ -99,6 +99,12 @@
     </ProjectProperties>
   </PropertyGroup>
 
+  <ItemDefinitionGroup>
+    <ProjectReference>
+      <PackageDirectory>Libraries</PackageDirectory>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+
   <!--
       CUSTOM TASKS
   -->
@@ -159,12 +165,10 @@
       <!-- We can now mark all the closure references as indirect -->
       <_ProjectReferenceClosure Include="@(_ProjectReferenceClosureWithoutMetadata)">
         <DependencyKind>Indirect</DependencyKind>
-        <PackageDirectory>%(ProjectReference.PackageDirectory)</PackageDirectory>
       </_ProjectReferenceClosure>
       <!-- Now add the direct references, preserving metadata -->
       <_ProjectReferenceClosure Include="@(ProjectReference->'%(FullPath)')">
         <DependencyKind>Direct</DependencyKind>
-        <PackageDirectory>%(ProjectReference.PackageDirectory)</PackageDirectory>
       </_ProjectReferenceClosure>
     </ItemGroup>
 
@@ -230,7 +234,7 @@
         <!-- Ask for the output and all dependencies. -->
 
         <MSBuild Targets="$(ProjectOutputGroups)"
-                 Projects="%(_NonNuProjProjectReference.Identity)"
+                 Projects="@(_NonNuProjProjectReference)"
                  Properties="$(ProjectProperties)">
             <Output TaskParameter="TargetOutputs"
                     ItemName="_NonNuProjProjectOutput" />
@@ -243,7 +247,7 @@
              get the directory name. -->
 
         <MSBuild Targets="GetTargetPath"
-                 Projects="%(_NonNuProjProjectReference.Identity)"
+                 Projects="@(_NonNuProjProjectReference)"
                  Properties="$(ProjectProperties)">
             <Output TaskParameter="TargetOutputs"
                     PropertyName="_NonNuProjProjectTargetPath" />
@@ -265,7 +269,7 @@
              NuGet package we need need to know the target framework moniker. -->
 
         <MSBuild Targets="GetTargetFrameworkMoniker"
-                 Projects="%(_NonNuProjProjectReference.Identity)"
+                 Projects="@(_NonNuProjProjectReference)"
                  Properties="$(ProjectProperties)">
           
             <Output TaskParameter="TargetOutputs"
@@ -275,7 +279,7 @@
         <!-- In order to add custom metadata, we need to create a new item list -->
 
         <CreateItem Include="@(_NonNuProjProjectOutput)"
-                    AdditionalMetadata="TargetFrameworkMoniker=$(_NonNuProjProjectTargetFrameworkMoniker);PackageDirectory=%(_NonNuProjProjectReference.PackageDirectory)">
+                    AdditionalMetadata="TargetFrameworkMoniker=$(_NonNuProjProjectTargetFrameworkMoniker)">
             <Output TaskParameter="Include"
                     ItemName="_NonNuProjProjectOutputWithTargetFrameworkMoniker"/>
         </CreateItem>
@@ -341,7 +345,7 @@
                           Condition="'%(File.TargetPath)' == 'lib' OR
                                      $([System.String]::Copy('%(File.TargetPath)').ToLower().StartsWith('lib\')) OR
                                      $([System.String]::Copy('%(File.TargetPath)').ToLower().StartsWith('lib/'))">
-        <PackageDirectory>Library</PackageDirectory>
+        <PackageDirectory>Libraries</PackageDirectory>
       </_FileWithIsLibrary>
       <_FileWithIsLibrary Include="@(File)"
                           Condition="'%(File.TargetPath)' != 'lib' AND
@@ -476,7 +480,7 @@
              Depending on referenced projects, single library can come from multiple locations,
              e.g target and intermediate output directories. -->
         <_RawLibraryTargetPath Include="@(File->'%(TargetPath)\%(FileName)%(Extension)')"
-                         Condition="'%(File.PackageDirectory)' == 'Library'">
+                         Condition="'%(File.PackageDirectory)' == 'Libraries'">
             <OriginalItemSpec>%(File.Identity)</OriginalItemSpec>
         </_RawLibraryTargetPath>
       </ItemGroup>
@@ -504,7 +508,7 @@
         <_FileTargetPath Include="@(_FilteredLibraryTargetPath->'%(FileName)%(Extension)')" />
 
         <_FileTargetPath Include="@(File->'::KEEP::')"
-                         Condition="'%(File.PackageDirectory)' != 'Library'">
+                         Condition="'%(File.PackageDirectory)' != 'Libraries'">
             <OriginalItemSpec>%(File.Identity)</OriginalItemSpec>
         </_FileTargetPath>
 
@@ -641,7 +645,7 @@
       
       <!-- Get files that are library and have assigned target framework (so no debug symbols files). -->
       <_DependencyFile Include="@(File)" 
-                       Condition="'%(File.PackageDirectory)' == 'Library' 
+                       Condition="'%(File.PackageDirectory)' == 'Libraries' 
                          and '%(File.TargetFramework)' != '' 
                          and '%(File.NuProjPackageId)' == '%(NuProjDependency.Identity)'"/>
       

--- a/src/NuProj.Targets/NuProj.targets
+++ b/src/NuProj.Targets/NuProj.targets
@@ -99,9 +99,16 @@
     </ProjectProperties>
   </PropertyGroup>
 
+  <!--
+      ITEM DEFINITIONS
+      
+      Defines default metadata for our items.
+  -->
+  
   <ItemDefinitionGroup>
     <ProjectReference>
       <PackageDirectory>Libraries</PackageDirectory>
+      <TargetFramework></TargetFramework>
     </ProjectReference>
   </ItemDefinitionGroup>
 
@@ -165,6 +172,7 @@
       <!-- We can now mark all the closure references as indirect -->
       <_ProjectReferenceClosure Include="@(_ProjectReferenceClosureWithoutMetadata)">
         <DependencyKind>Indirect</DependencyKind>
+        <PackageDirectory>%(ProjectReference.PackageDirectory)</PackageDirectory>
       </_ProjectReferenceClosure>
       <!-- Now add the direct references, preserving metadata -->
       <_ProjectReferenceClosure Include="@(ProjectReference->'%(FullPath)')">
@@ -726,23 +734,14 @@
     =================================================================================================================== -->
 
   <Target Name="GetNuGetPackageDependencies"
-          Inputs="%(_ProjectReferenceClosure.DependencyKind)"
-          Outputs="fake"
           Returns="@(NuGetDependency)">
 
       <!-- Read each project's packages.config file. -->
-      <ReadPackagesConfig ProjectPath="%(_ProjectReferenceClosure.FullPath)"
-                          Condition="'%(_ProjectReferenceClosure.FullPath)' != ''">
+      <ReadPackagesConfig Projects="@(_ProjectReferenceClosure)"
+                          Condition="'%(PackageDirectory)' == 'Libraries'">
         <Output TaskParameter="PackageReferences"
                 ItemName="_PackageReference" />
       </ReadPackagesConfig>
-
-      <!-- Unfortunately, we can't use %(_ProjectReferenceClosure.DependencyKind) to
-           define the metadata in the declaration of NuGetDependency.DependencyKind.
-           So we simply capture the current batch in a property. -->
-      <PropertyGroup>
-        <_ProjectReferenceClosureDependencyKind>%(_ProjectReferenceClosure.DependencyKind)</_ProjectReferenceClosureDependencyKind>
-      </PropertyGroup>
 
       <!-- Turn all dependencies into NuGetDependency items with appropriate metadata. -->
       <ItemGroup Condition="'@(_PackageReference)' != ''">
@@ -750,7 +749,6 @@
                          Condition="!%(IsDevelopmentDependency)"
                          RemoveMetadata="IsDevelopmentDependency;RequireReinstallation;VersionConstraint">
           <Version Condition="'%(_PackageReference.VersionConstraint)' != ''">%(_PackageReference.VersionConstraint)</Version>
-          <DependencyKind>$(_ProjectReferenceClosureDependencyKind)</DependencyKind>
         </NuGetDependency>
       </ItemGroup>
 

--- a/src/NuProj.Targets/NuProj.targets
+++ b/src/NuProj.Targets/NuProj.targets
@@ -95,7 +95,13 @@
   <PropertyGroup>
     <ProjectProperties>
       Configuration=$(Configuration);
-      Platform=$(Platform);
+      Platform=$(Platform)
+    </ProjectProperties>
+
+    <!-- Use 'Microsoft.Common.NuProj.targets' if it's in same directory as this script. 
+         For example when using NuProj NuGet package instead of VS integration.-->
+    <ProjectProperties Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.Common.NuProj.targets') And !$(CustomAfterMicrosoftCommonTargets.Contains('Microsoft.Common.NuProj.targets'))">
+      $(ProjectProperties);CustomAfterMicrosoftCommonTargets=$(MSBuildThisFileDirectory)Microsoft.Common.NuProj.targets
     </ProjectProperties>
   </PropertyGroup>
 

--- a/src/NuProj.Targets/NuProj.targets
+++ b/src/NuProj.Targets/NuProj.targets
@@ -126,6 +126,8 @@
     =================================================================================================================== -->
 
   <Target Name="_NuProjGetProjectClosure"
+          Inputs="%(ProjectReference.Identity)"
+          Outputs="fake"
           Returns="@(_ProjectReferenceClosure)">
     <!-- First let's make sure that the project references have been fully build,
              unless building project references is disabled. -->
@@ -157,10 +159,12 @@
       <!-- We can now mark all the closure references as indirect -->
       <_ProjectReferenceClosure Include="@(_ProjectReferenceClosureWithoutMetadata)">
         <DependencyKind>Indirect</DependencyKind>
+        <PackageDirectory>%(ProjectReference.PackageDirectory)</PackageDirectory>
       </_ProjectReferenceClosure>
       <!-- Now add the direct references -->
       <_ProjectReferenceClosure Include="%(ProjectReference.FullPath)">
         <DependencyKind>Direct</DependencyKind>
+        <PackageDirectory>%(ProjectReference.PackageDirectory)</PackageDirectory>
       </_ProjectReferenceClosure>
     </ItemGroup>
 
@@ -214,7 +218,7 @@
         @(ProjectReference)         The project references
 
     OUTPUTS:
-        @(Library)                  The library Files to be packaged
+        @(ProjectReferenceOutput)   The output of all project references
 
     =================================================================================================================== -->
 
@@ -263,6 +267,7 @@
         <MSBuild Targets="GetTargetFrameworkMoniker"
                  Projects="%(_NonNuProjProjectReference.Identity)"
                  Properties="$(ProjectProperties)">
+          
             <Output TaskParameter="TargetOutputs"
                     PropertyName="_NonNuProjProjectTargetFrameworkMoniker" />
         </MSBuild>
@@ -270,7 +275,7 @@
         <!-- In order to add custom metadata, we need to create a new item list -->
 
         <CreateItem Include="@(_NonNuProjProjectOutput)"
-                    AdditionalMetadata="TargetFrameworkMoniker=$(_NonNuProjProjectTargetFrameworkMoniker)">
+                    AdditionalMetadata="TargetFrameworkMoniker=$(_NonNuProjProjectTargetFrameworkMoniker);PackageDirectory=%(_NonNuProjProjectReference.PackageDirectory)">
             <Output TaskParameter="Include"
                     ItemName="_NonNuProjProjectOutputWithTargetFrameworkMoniker"/>
         </CreateItem>
@@ -281,8 +286,8 @@
              lib\net40\foo.dll -->
 
         <AssignTargetFramework OutputsWithTargetFrameworkInformation="@(_NonNuProjProjectOutputWithTargetFrameworkMoniker)">
-            <Output TaskParameter="Libraries"
-                    ItemName="Library" />
+            <Output TaskParameter="PackageFiles"
+                    ItemName="ProjectReferenceOutput" />
         </AssignTargetFramework>
 
     </Target>
@@ -296,7 +301,7 @@
     be packaged.
 
     INPUTS:
-        @(Library)                  Library items to be packaged
+        @(ProjectReferenceOutput)   Output of referenced projects to be packaged
         @(Content)                  Content items to be packaged
 
     OUTPUTS:
@@ -306,8 +311,7 @@
 
   <Target Name="ConvertItems"
           DependsOnTargets="ExpandProjectReferences">
-    <CreateItem Include="@(Library)"
-                AdditionalMetadata="TargetPath=lib\%(Library.TargetFramework)">
+    <CreateItem Include="@(ProjectReferenceOutput)">
       <Output TaskParameter="Include"
               ItemName="File"/>
     </CreateItem>
@@ -327,11 +331,6 @@
       <Output TaskParameter="Include"
               ItemName="File"/>
     </CreateItem>
-    <CreateItem Include="@(Tool)"
-                AdditionalMetadata="TargetPath=tools\%(Tool.TargetPath)">
-      <Output TaskParameter="Include"
-              ItemName="File"/>
-    </CreateItem>
 
     <!-- We need to special case library files in later phases. In order to make this
          easier, we add custom metadata 'IsLibrary' that indicates whether the file is
@@ -342,13 +341,13 @@
                           Condition="'%(File.TargetPath)' == 'lib' OR
                                      $([System.String]::Copy('%(File.TargetPath)').ToLower().StartsWith('lib\')) OR
                                      $([System.String]::Copy('%(File.TargetPath)').ToLower().StartsWith('lib/'))">
-        <IsLibrary>True</IsLibrary>
+        <PackageDirectory>Library</PackageDirectory>
       </_FileWithIsLibrary>
       <_FileWithIsLibrary Include="@(File)"
                           Condition="'%(File.TargetPath)' != 'lib' AND
                                      !$([System.String]::Copy('%(File.TargetPath)').ToLower().StartsWith('lib\')) AND
                                      !$([System.String]::Copy('%(File.TargetPath)').ToLower().StartsWith('lib/'))">
-        <IsLibrary>False</IsLibrary>
+        <PackageDirectory></PackageDirectory>
       </_FileWithIsLibrary>
       <File Remove="@(File)" />
       <File Include="@(_FileWithIsLibrary)" />
@@ -476,7 +475,7 @@
              Depending on referenced projects, single library can come from multiple locations,
              e.g target and intermediate output directories. -->
         <_RawLibraryTargetPath Include="@(File->'%(TargetPath)\%(FileName)%(Extension)')"
-                         Condition="'%(File.IsLibrary)' == 'True'">
+                         Condition="'%(File.PackageDirectory)' == 'Library'">
             <OriginalItemSpec>%(File.Identity)</OriginalItemSpec>
         </_RawLibraryTargetPath>
       </ItemGroup>
@@ -504,7 +503,7 @@
         <_FileTargetPath Include="@(_FilteredLibraryTargetPath->'%(FileName)%(Extension)')" />
 
         <_FileTargetPath Include="@(File->'::KEEP::')"
-                         Condition="'%(File.IsLibrary)' == 'False'">
+                         Condition="'%(File.PackageDirectory)' != 'Library'">
             <OriginalItemSpec>%(File.Identity)</OriginalItemSpec>
         </_FileTargetPath>
 
@@ -641,7 +640,7 @@
       
       <!-- Get files that are library and have assigned target framework (so no debug symbols files). -->
       <_DependencyFile Include="@(File)" 
-                       Condition="'%(File.IsLibrary)' == 'True' 
+                       Condition="'%(File.PackageDirectory)' == 'Library' 
                          and '%(File.TargetFramework)' != '' 
                          and '%(File.NuProjPackageId)' == '%(NuProjDependency.Identity)'"/>
       

--- a/src/NuProj.Tasks/Extensions.cs
+++ b/src/NuProj.Tasks/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -52,6 +53,19 @@ namespace NuProj.Tasks
                 result = NullFramework;
             }
 
+            return result;
+        }
+
+        public static PackageDirectory GetPackageDirectory(this ITaskItem taskItem)
+        {
+            var packageDirectoryName = taskItem.GetMetadata(Metadata.PackageDirectory);
+            if (string.IsNullOrEmpty(packageDirectoryName))
+            {
+                return PackageDirectory.Libraries;
+            }
+
+            PackageDirectory result;
+            Enum.TryParse(packageDirectoryName, true, out result);
             return result;
         }
 
@@ -142,6 +156,25 @@ namespace NuProj.Tasks
             list.AddRange(value);
             
             property.SetValue(target, list, null);
+        }
+
+        public static string Combine(this PackageDirectory packageDirectory, string targetFramework, string fileName)
+        { 
+            switch (packageDirectory)
+            {
+                case PackageDirectory.Root:
+                    return fileName;
+                case PackageDirectory.Content:
+                    return Path.Combine(Constants.ContentDirectory, fileName);
+                case PackageDirectory.Build:
+                    return Path.Combine(Constants.BuildDirectory, targetFramework, fileName);
+                case PackageDirectory.Libraries:
+                    return Path.Combine(Constants.LibDirectory, targetFramework, fileName);
+                case PackageDirectory.Tools:
+                    return Path.Combine(Constants.ToolsDirectory, targetFramework, fileName);
+                default:
+                    return fileName;
+            }
         }
     }
 }

--- a/src/NuProj.Tasks/Extensions.cs
+++ b/src/NuProj.Tasks/Extensions.cs
@@ -61,7 +61,7 @@ namespace NuProj.Tasks
             var packageDirectoryName = taskItem.GetMetadata(Metadata.PackageDirectory);
             if (string.IsNullOrEmpty(packageDirectoryName))
             {
-                return PackageDirectory.Libraries;
+                return PackageDirectory.Lib;
             }
 
             PackageDirectory result;
@@ -168,7 +168,7 @@ namespace NuProj.Tasks
                     return Path.Combine(Constants.ContentDirectory, fileName);
                 case PackageDirectory.Build:
                     return Path.Combine(Constants.BuildDirectory, fileName);
-                case PackageDirectory.Libraries:
+                case PackageDirectory.Lib:
                     return Path.Combine(Constants.LibDirectory, targetFramework, fileName);
                 case PackageDirectory.Tools:
                     return Path.Combine(Constants.ToolsDirectory, fileName);

--- a/src/NuProj.Tasks/Extensions.cs
+++ b/src/NuProj.Tasks/Extensions.cs
@@ -167,11 +167,11 @@ namespace NuProj.Tasks
                 case PackageDirectory.Content:
                     return Path.Combine(Constants.ContentDirectory, fileName);
                 case PackageDirectory.Build:
-                    return Path.Combine(Constants.BuildDirectory, targetFramework, fileName);
+                    return Path.Combine(Constants.BuildDirectory, fileName);
                 case PackageDirectory.Libraries:
                     return Path.Combine(Constants.LibDirectory, targetFramework, fileName);
                 case PackageDirectory.Tools:
-                    return Path.Combine(Constants.ToolsDirectory, targetFramework, fileName);
+                    return Path.Combine(Constants.ToolsDirectory, fileName);
                 default:
                     return fileName;
             }

--- a/src/NuProj.Tasks/Metadata.cs
+++ b/src/NuProj.Tasks/Metadata.cs
@@ -7,6 +7,8 @@
         public const string FileSource = "FullPath";
         
         public const string FileTarget = "TargetPath";
+
+        public const string PackageDirectory = "PackageDirectory";
         
         public const string TargetFramework = "TargetFramework";
 

--- a/src/NuProj.Tasks/NuProj.Tasks.csproj
+++ b/src/NuProj.Tasks/NuProj.Tasks.csproj
@@ -65,6 +65,7 @@
     <Compile Include="ReadPackagesConfig.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReadPdbSourceFiles.cs" />
+    <Compile Include="PackageDirectory.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\NuProj.Targets\Microsoft.Common.NuProj.targets">

--- a/src/NuProj.Tasks/PackageDirectory.cs
+++ b/src/NuProj.Tasks/PackageDirectory.cs
@@ -10,7 +10,7 @@ namespace NuProj.Tasks
     public enum PackageDirectory
     {
         Root,
-        Libraries,
+        Lib,
         Tools,
         Content,
         Build,

--- a/src/NuProj.Tasks/PackageDirectory.cs
+++ b/src/NuProj.Tasks/PackageDirectory.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NuProj.Tasks
+{
+    public enum PackageDirectory
+    {
+        Root,
+        Libraries,
+        Tools,
+        Content,
+        Build,
+    }
+}

--- a/src/NuProj.Tests/DependencyTests.cs
+++ b/src/NuProj.Tests/DependencyTests.cs
@@ -59,7 +59,7 @@ namespace NuProj.Tests
         [Fact]
         public async Task Dependency_IndirectDependencies_AreNotPackaged()
         {
-            var package = await Scenario.RestoreAndBuildSinglePackage("Dependency_IndirectDependencies_AreNotPackaged", "A");
+            var package = await Scenario.RestoreAndBuildSinglePackage("Dependency_IndirectDependencies_AreNotPackaged", "A.nuget");
             var files = package.GetFiles();
 
             Assert.None(files, x => x.Path.Contains("Newtonsoft.Json.dll"));
@@ -70,7 +70,7 @@ namespace NuProj.Tests
         [Fact]
         public async Task Dependency_DirectDependencies_AreNotPackaged()
         {
-            var package = await Scenario.RestoreAndBuildSinglePackage("Dependency_DirectDependencies_AreNotPackaged", "A");
+            var package = await Scenario.RestoreAndBuildSinglePackage("Dependency_DirectDependencies_AreNotPackaged", "A.nuget");
             var files = package.GetFiles();
 
             Assert.None(files, x => x.Path.Contains("Newtonsoft.Json.dll"));
@@ -100,11 +100,11 @@ namespace NuProj.Tests
         {
             var package = await Scenario.RestoreAndBuildSinglePackage(
                 "Dependency_MultipleFrameworks_AreResolved", 
-                "Dependent");
+                "Dependent.nuget");
             var dependencySet = new []{
                 new PackageDependencySet(VersionUtility.ParseFrameworkName("net40"), new List<PackageDependency>
                     {
-                        new PackageDependency("Dependency", new VersionSpec
+                        new PackageDependency("Dependency.nuget", new VersionSpec
                             {
                                 IsMinInclusive = true,
                                 MinVersion = new SemanticVersion("1.0.0")
@@ -112,7 +112,7 @@ namespace NuProj.Tests
                     }),
                 new PackageDependencySet(VersionUtility.ParseFrameworkName("net45"), new List<PackageDependency>
                     {
-                        new PackageDependency("Dependency", new VersionSpec
+                        new PackageDependency("Dependency.nuget", new VersionSpec
                             {
                                 IsMinInclusive = true,
                                 MinVersion = new SemanticVersion("1.0.0")

--- a/src/NuProj.Tests/Infrastructure/Extensions.cs
+++ b/src/NuProj.Tests/Infrastructure/Extensions.cs
@@ -1,13 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using NuGet;
 
 namespace NuProj.Tests.Infrastructure
 {
     public static class Extensions
     {
+        public static IEnumerable<string> Flatten(this IEnumerable<PackageDependencySet> dependencySets)
+        {
+            return from formattedDependency in
+                       (from dependencySet in dependencySets
+                        from dependency in dependencySet.Dependencies
+                        select dependencySet.TargetFramework == null
+                        ? dependency.ToString()
+                        : string.Format("{0} ({1})", dependency, VersionUtility.GetShortFrameworkName(dependencySet.TargetFramework)))
+                   select formattedDependency.Replace("\u2265", ">=").Replace("\u2264", "<=");
+        }
+
         public static IEnumerable<T> NullAsEmpty<T>(this IEnumerable<T> source)
         {
             if (source == null)
@@ -17,6 +26,5 @@ namespace NuProj.Tests.Infrastructure
 
             return source;
         }
-
     }
 }

--- a/src/NuProj.Tests/Infrastructure/MSBuild.cs
+++ b/src/NuProj.Tests/Infrastructure/MSBuild.cs
@@ -14,9 +14,11 @@ namespace NuProj.Tests.Infrastructure
 {
     public static class MSBuild
     {
-        public static Task<BuildResultAndLogs> RebuildAsync(string projectPath, IDictionary<string, string> properties = null)
+        public static Task<BuildResultAndLogs> RebuildAsync(string projectPath, string projectName = null, IDictionary<string, string> properties = null)
         {
-            return MSBuild.ExecuteAsync(projectPath, new[] { "Rebuild" }, properties);
+
+            var target = string.IsNullOrEmpty(projectName) ? "Rebuild" : projectName.Replace('.', '_') + ":Rebuild";
+            return MSBuild.ExecuteAsync(projectPath, new[] { target }, properties);
         }
 
         public static Task<BuildResultAndLogs> ExecuteAsync(string projectPath, string targetToBuild, IDictionary<string, string> properties = null)
@@ -172,6 +174,12 @@ namespace NuProj.Tests.Infrastructure
             {
                 Assert.False(ErrorEvents.Any(), ErrorEvents.Select(e => e.Message).FirstOrDefault());
                 Assert.Equal(BuildResultCode.Success, Result.OverallResult);
+            }
+
+            public void AssertUnsuccessfulBuild()
+            {
+                Assert.Equal(BuildResultCode.Failure, Result.OverallResult);
+                Assert.True(ErrorEvents.Any(), ErrorEvents.Select(e => e.Message).FirstOrDefault());
             }
         }
 

--- a/src/NuProj.Tests/Infrastructure/Scenario.cs
+++ b/src/NuProj.Tests/Infrastructure/Scenario.cs
@@ -12,23 +12,36 @@ namespace NuProj.Tests.Infrastructure
     {
         public static async Task<IPackage> RestoreAndBuildSinglePackage(string scenarioName, string packageId = null, IDictionary<string, string> properties = null)
         {
-            var packages = await RestoreAndBuildPackages(scenarioName, properties);
+            var packages = await RestoreAndBuildPackages(scenarioName, packageId, properties);
             return packageId == null
                     ? packages.Single()
                     : packages.Single(p => string.Equals(p.Id, packageId, StringComparison.OrdinalIgnoreCase));
         }
 
-        public static async Task<IReadOnlyCollection<IPackage>> RestoreAndBuildPackages(string scenarioName, IDictionary<string, string> properties = null)
+        public static async Task<IReadOnlyCollection<IPackage>> RestoreAndBuildPackages(string scenarioName, string packageId, IDictionary<string, string> properties = null)
         {
             var projectFullPath = Assets.GetScenarioSolutionPath(scenarioName);
 
             var projectDirectory = Path.GetDirectoryName(projectFullPath);
             await NuGetHelper.RestorePackagesAsync(projectDirectory);
 
-            var result = await MSBuild.RebuildAsync(projectFullPath, properties);
+            var result = await MSBuild.RebuildAsync(projectFullPath, packageId, properties);
             result.AssertSuccessfulBuild();
 
             return NuPkg.GetPackages(projectDirectory);
+        }
+
+        public static async Task RestoreAndFailBuild(string scenarioName, string packageId, IDictionary<string, string> properties = null)
+        {
+            var projectFullPath = Assets.GetScenarioSolutionPath(scenarioName);
+
+            var projectDirectory = Path.GetDirectoryName(projectFullPath);
+            await NuGetHelper.RestorePackagesAsync(projectDirectory);
+
+            var result = await MSBuild.RebuildAsync(projectFullPath, packageId, properties);
+
+            result.AssertUnsuccessfulBuild();
+
         }
     }
 }

--- a/src/NuProj.Tests/PackageIdentityTests.cs
+++ b/src/NuProj.Tests/PackageIdentityTests.cs
@@ -11,7 +11,7 @@ namespace NuProj.Tests
     public class PackageIdentityTests
     {
         [Theory]
-        [InlineData("Dependency_IndirectDependencies_AreNotPackaged", @"A.nuget\A.nuget.nuproj", "A")]
+        [InlineData("Dependency_IndirectDependencies_AreNotPackaged", @"A.nuget\A.nuget.nuproj", "A.nuget")]
         public async Task PackageIdentity_GetPackageIdentity_ResturnsCorrectValue(string scenarioName, string projectToBuild, string identity)
         {
             const string target = "GetPackageIdentity";

--- a/src/NuProj.Tests/ReadPackagesConfigTests.cs
+++ b/src/NuProj.Tests/ReadPackagesConfigTests.cs
@@ -1,10 +1,8 @@
 ﻿using System.Linq;
-
+using Microsoft.Build.Utilities;
 using NuGet;
-
 using NuProj.Tasks;
 using NuProj.Tests.Infrastructure;
-
 using Xunit;
 
 namespace NuProj.Tests
@@ -17,7 +15,7 @@ namespace NuProj.Tests
             var projectPath = Assets.GetScenarioFilePath("Task_ReadPackagesConfig_ParseProjectoryConfig", @"A.csproj");
 
             var task = new ReadPackagesConfig();
-            task.ProjectPath = projectPath;
+            task.Projects = new[] { new TaskItem(projectPath) };
             var result = task.Execute();
 
             var expectedVersionConstraint = VersionUtility.ParseVersionSpec("[1,2]").ToString();
@@ -40,7 +38,7 @@ namespace NuProj.Tests
             var projectPath = Assets.GetScenarioFilePath("Task_ReadPackagesConfig_ParseDirectoryConfig", @"B.csproj");
 
             var task = new ReadPackagesConfig();
-            task.ProjectPath = projectPath;
+            task.Projects = new[] { new TaskItem(projectPath) };
             var result = task.Execute();
 
             Assert.True(result);
@@ -57,7 +55,7 @@ namespace NuProj.Tests
             var projectPath = Assets.GetScenarioFilePath("Task_ReadPackagesConfig_NoConfig", @"C.csproj");
 
             var task = new ReadPackagesConfig();
-            task.ProjectPath = projectPath;
+            task.Projects = new[] { new TaskItem(projectPath) };
             var result = task.Execute();
 
             Assert.True(result);

--- a/src/NuProj.Tests/ReferenceTests.cs
+++ b/src/NuProj.Tests/ReferenceTests.cs
@@ -43,6 +43,28 @@ namespace NuProj.Tests
             var files = package.GetFiles().Select(f => f.Path);
             Assert.Equal(expectedFileNames, files);
         }
+
+        [Theory]
+        [InlineData("PackageToBuild", new[] { @"build\net45\Tool.dll" })]
+        [InlineData("PackageToLib", new[] { @"lib\net45\Tool.dll" })]
+        [InlineData("PackageToRoot", new[] { @"Tool.dll", @"Tool.pdb" })]
+        [InlineData("PackageToTools", new[] { @"tools\net45\Tool.dll" })]
+        [InlineData("PackageDependencyToTools", new[] { @"tools\net45\Tool.dll" })]
+        [InlineData("PackageClosureToTools", new[] { @"tools\net45\Tool.dll", @"tools\net45\ToolWithClosure.dll" })]
+        public async Task References_PackageDirectory_ToolIsPackaged(string packageId, string[] expectedFiles)
+        {
+            var package = await Scenario.RestoreAndBuildSinglePackage("References_PackageDirectory", packageId);
+            var files = package.GetFiles().Select(f => f.Path);
+            Assert.Equal(expectedFiles.OrderBy(x => x), files.OrderBy(x => x));
+        }
+
+        [Theory]
+        [InlineData("PackageToContent")]
+        public async Task References_PackageDirectory_Fails(string packageId)
+        {
+            await Scenario.RestoreAndFailBuild("References_PackageDirectory", packageId);
+        }
+
     }
 }
     

--- a/src/NuProj.Tests/ReferenceTests.cs
+++ b/src/NuProj.Tests/ReferenceTests.cs
@@ -51,20 +51,13 @@ namespace NuProj.Tests
         [InlineData("PackageToTools", new[] { @"tools\Tool.dll" })]
         [InlineData("PackageDependencyToTools", new[] { @"tools\Tool.dll" })]
         [InlineData("PackageClosureToTools", new[] { @"tools\Tool.dll", @"tools\ToolWithClosure.dll" })]
+        [InlineData("PackageToContent", new[] { @"content\Tool.dll", @"content\Tool.pdb" })]
         public async Task References_PackageDirectory_ToolIsPackaged(string packageId, string[] expectedFiles)
         {
             var package = await Scenario.RestoreAndBuildSinglePackage("References_PackageDirectory", packageId);
             var files = package.GetFiles().Select(f => f.Path);
             Assert.Equal(expectedFiles.OrderBy(x => x), files.OrderBy(x => x));
         }
-
-        [Theory]
-        [InlineData("PackageToContent")]
-        public async Task References_PackageDirectory_Fails(string packageId)
-        {
-            await Scenario.RestoreAndFailBuild("References_PackageDirectory", packageId);
-        }
-
     }
 }
     

--- a/src/NuProj.Tests/ReferenceTests.cs
+++ b/src/NuProj.Tests/ReferenceTests.cs
@@ -45,12 +45,12 @@ namespace NuProj.Tests
         }
 
         [Theory]
-        [InlineData("PackageToBuild", new[] { @"build\net45\Tool.dll" })]
+        [InlineData("PackageToBuild", new[] { @"build\Tool.dll" })]
         [InlineData("PackageToLib", new[] { @"lib\net45\Tool.dll" })]
         [InlineData("PackageToRoot", new[] { @"Tool.dll", @"Tool.pdb" })]
-        [InlineData("PackageToTools", new[] { @"tools\net45\Tool.dll" })]
-        [InlineData("PackageDependencyToTools", new[] { @"tools\net45\Tool.dll" })]
-        [InlineData("PackageClosureToTools", new[] { @"tools\net45\Tool.dll", @"tools\net45\ToolWithClosure.dll" })]
+        [InlineData("PackageToTools", new[] { @"tools\Tool.dll" })]
+        [InlineData("PackageDependencyToTools", new[] { @"tools\Tool.dll" })]
+        [InlineData("PackageClosureToTools", new[] { @"tools\Tool.dll", @"tools\ToolWithClosure.dll" })]
         public async Task References_PackageDirectory_ToolIsPackaged(string packageId, string[] expectedFiles)
         {
             var package = await Scenario.RestoreAndBuildSinglePackage("References_PackageDirectory", packageId);

--- a/src/NuProj.Tests/ReferenceTests.cs
+++ b/src/NuProj.Tests/ReferenceTests.cs
@@ -45,18 +45,26 @@ namespace NuProj.Tests
         }
 
         [Theory]
-        [InlineData("PackageToBuild", new[] { @"build\Tool.dll" })]
-        [InlineData("PackageToLib", new[] { @"lib\net45\Tool.dll" })]
-        [InlineData("PackageToRoot", new[] { @"Tool.dll", @"Tool.pdb" })]
-        [InlineData("PackageToTools", new[] { @"tools\Tool.dll" })]
-        [InlineData("PackageDependencyToTools", new[] { @"tools\Tool.dll" })]
-        [InlineData("PackageClosureToTools", new[] { @"tools\Tool.dll", @"tools\ToolWithClosure.dll" })]
-        [InlineData("PackageToContent", new[] { @"content\Tool.dll", @"content\Tool.pdb" })]
-        public async Task References_PackageDirectory_ToolIsPackaged(string packageId, string[] expectedFiles)
+        [InlineData("PackageToBuild", new[] { @"build\Tool.dll" }, new string[0])]
+        [InlineData("PackageToLib", new[] { @"lib\net45\Tool.dll" }, new string[0])]
+        [InlineData("PackageToRoot", new[] { @"Tool.dll", @"Tool.pdb" }, new string[0])]
+        [InlineData("PackageToTools", new[] { @"tools\Tool.dll" }, new string[0])]
+        [InlineData("PackageDependencyToTools", new[] { @"tools\Tool.dll" }, new[] { "PackageToTools (>= 1.0.0)" })]
+        [InlineData("PackageClosureToTools", new[] { @"tools\Tool.dll", @"tools\ToolWithClosure.dll" }, new string[0])]
+        [InlineData("PackageToContent", new[] { @"content\Tool.dll", @"content\Tool.pdb" }, new string[0])]
+        [InlineData("PackageNuGetDependencyToTools", new[] { @"tools\System.Collections.Immutable.dll", @"tools\ToolWithDependency.dll" }, new string[0])]
+        public async Task References_PackageDirectory_ToolIsPackaged(
+            string packageId, 
+            string[] expectedFiles, 
+            string[] expectedDependencies)
         {
             var package = await Scenario.RestoreAndBuildSinglePackage("References_PackageDirectory", packageId);
-            var files = package.GetFiles().Select(f => f.Path);
-            Assert.Equal(expectedFiles.OrderBy(x => x), files.OrderBy(x => x));
+            var actualFiles = package.GetFiles().Select(f => f.Path).OrderBy(x => x);
+            var actualDependencies = package.DependencySets.NullAsEmpty().Flatten().OrderBy(x => x);
+            expectedFiles = expectedFiles.OrderBy(x => x).ToArray();
+            expectedDependencies = expectedDependencies.OrderBy(x => x).ToArray();
+            Assert.Equal(expectedFiles, actualFiles);
+            Assert.Equal(expectedDependencies, actualDependencies);
         }
     }
 }

--- a/src/NuProj.Tests/Scenarios/Dependency_DirectDependencies_AreNotPackaged/A.nuget/A.nuget.nuproj
+++ b/src/NuProj.Tests/Scenarios/Dependency_DirectDependencies_AreNotPackaged/A.nuget/A.nuget.nuproj
@@ -18,9 +18,9 @@
   </PropertyGroup>
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
-    <Id>A</Id>
+    <Id>A.nuget</Id>
     <Version>1.0.0</Version>
-    <Title>B.nuget</Title>
+    <Title>A.nuget</Title>
     <Authors>nuproj</Authors>
     <Owners>nuproj</Owners>
     <Summary>A</Summary>

--- a/src/NuProj.Tests/Scenarios/Dependency_IndirectDependencies_AreNotPackaged/A.nuget/A.nuget.nuproj
+++ b/src/NuProj.Tests/Scenarios/Dependency_IndirectDependencies_AreNotPackaged/A.nuget/A.nuget.nuproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
-    <Id>A</Id>
+    <Id>A.nuget</Id>
     <Version>1.0.0</Version>
     <Title>B.nuget</Title>
     <Authors>nuproj</Authors>

--- a/src/NuProj.Tests/Scenarios/Dependency_MultipleFrameworks_AreResolved/Dependency.nuget/Dependency.nuget.nuproj
+++ b/src/NuProj.Tests/Scenarios/Dependency_MultipleFrameworks_AreResolved/Dependency.nuget/Dependency.nuget.nuproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
-    <Id>Dependency</Id>
+    <Id>Dependency.nuget</Id>
     <Version>1.0.0</Version>
     <Title>Dependency</Title>
     <Authors>kovalikp</Authors>

--- a/src/NuProj.Tests/Scenarios/References_PackageDirectory/PackageClosureToTools/PackageClosureToTools.nuproj
+++ b/src/NuProj.Tests/Scenarios/References_PackageDirectory/PackageClosureToTools/PackageClosureToTools.nuproj
@@ -11,20 +11,20 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>6a1ca851-c20e-4d96-a185-c8d8a99dfb47</ProjectGuid>
+    <ProjectGuid>2ed4f53c-67d7-457a-88d9-b91fe44b40a3</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup>
     <NuProjPath Condition=" '$(NuProjPath)' == '' ">$(MSBuildExtensionsPath)\NuProj\</NuProjPath>
   </PropertyGroup>
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
-    <Id>Dependent.nuget</Id>
+    <Id>PackageClosureToTools</Id>
     <Version>1.0.0</Version>
-    <Title>Dependent</Title>
+    <Title>PackageClosureToTools</Title>
     <Authors>kovalikp</Authors>
     <Owners>kovalikp</Owners>
-    <Summary>Dependent</Summary>
-    <Description>Dependent</Description>
+    <Summary>PackageClosureToTools</Summary>
+    <Description>PackageClosureToTools</Description>
     <ReleaseNotes>
     </ReleaseNotes>
     <ProjectUrl>
@@ -32,15 +32,12 @@
     <LicenseUrl>
     </LicenseUrl>
     <Copyright>Copyright © kovalikp</Copyright>
-    <Tags>Dependent</Tags>
+    <Tags>PackageClosureToTools</Tags>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="Readme.txt" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Dependency.nuget\Dependency.nuget.nuproj" />
-    <ProjectReference Include="..\Dependent\Dependent.net40.csproj" />
-    <ProjectReference Include="..\Dependent\Dependent.net45.csproj" />
+    <ProjectReference Include="..\ToolWithClosure\ToolWithClosure.csproj">
+      <PackageDirectory>Tools</PackageDirectory>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(NuProjPath)\NuProj.targets" />
 </Project>

--- a/src/NuProj.Tests/Scenarios/References_PackageDirectory/PackageDependencyToTools/PackageDependencyToTools.nuproj
+++ b/src/NuProj.Tests/Scenarios/References_PackageDirectory/PackageDependencyToTools/PackageDependencyToTools.nuproj
@@ -11,20 +11,20 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>6a1ca851-c20e-4d96-a185-c8d8a99dfb47</ProjectGuid>
+    <ProjectGuid>57396cea-46e7-49df-bfa6-5dd5d9141108</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup>
     <NuProjPath Condition=" '$(NuProjPath)' == '' ">$(MSBuildExtensionsPath)\NuProj\</NuProjPath>
   </PropertyGroup>
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
-    <Id>Dependent.nuget</Id>
+    <Id>PackageDependencyToTools</Id>
     <Version>1.0.0</Version>
-    <Title>Dependent</Title>
+    <Title>PackageDependencyToTools</Title>
     <Authors>kovalikp</Authors>
     <Owners>kovalikp</Owners>
-    <Summary>Dependent</Summary>
-    <Description>Dependent</Description>
+    <Summary>PackageDependencyToTools</Summary>
+    <Description>PackageDependencyToTools</Description>
     <ReleaseNotes>
     </ReleaseNotes>
     <ProjectUrl>
@@ -32,15 +32,13 @@
     <LicenseUrl>
     </LicenseUrl>
     <Copyright>Copyright © kovalikp</Copyright>
-    <Tags>Dependent</Tags>
+    <Tags>PackageDependencyToTools</Tags>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="Readme.txt" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Dependency.nuget\Dependency.nuget.nuproj" />
-    <ProjectReference Include="..\Dependent\Dependent.net40.csproj" />
-    <ProjectReference Include="..\Dependent\Dependent.net45.csproj" />
+    <ProjectReference Include="..\PackageToTools\PackageToTools.nuproj" />
+    <ProjectReference Include="..\Tool\Tool.csproj">
+      <PackageDirectory>Tools</PackageDirectory>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(NuProjPath)\NuProj.targets" />
 </Project>

--- a/src/NuProj.Tests/Scenarios/References_PackageDirectory/PackageNuGetDependencyToTools/PackageNuGetDependencyToTools.nuproj
+++ b/src/NuProj.Tests/Scenarios/References_PackageDirectory/PackageNuGetDependencyToTools/PackageNuGetDependencyToTools.nuproj
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|AnyCPU">
+      <Configuration>Debug</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|AnyCPU">
+      <Configuration>Release</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>d8930c85-e974-4caf-8a93-716eeae3b98b</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup>
+    <NuProjPath Condition=" '$(NuProjPath)' == '' ">$(MSBuildExtensionsPath)\NuProj\</NuProjPath>
+  </PropertyGroup>
+  <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
+  <PropertyGroup Label="Configuration">
+    <Id>PackageNuGetDependencyToTools</Id>
+    <Version>1.0.0</Version>
+    <Title>PackageNuGetDependencyToTools</Title>
+    <Authors>kovalikp</Authors>
+    <Owners>kovalikp</Owners>
+    <Summary>PackageNuGetDependencyToTools</Summary>
+    <Description>PackageNuGetDependencyToTools</Description>
+    <ReleaseNotes>
+    </ReleaseNotes>
+    <ProjectUrl>
+    </ProjectUrl>
+    <LicenseUrl>
+    </LicenseUrl>
+    <Copyright>Copyright © kovalikp</Copyright>
+    <Tags>PackageNuGetDependencyToTools</Tags>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ToolWithDependency\ToolWithDependency.csproj">
+      <PackageDirectory>Tools</PackageDirectory>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(NuProjPath)\NuProj.targets" />
+</Project>

--- a/src/NuProj.Tests/Scenarios/References_PackageDirectory/PackageToBuild/PackageToBuild.nuproj
+++ b/src/NuProj.Tests/Scenarios/References_PackageDirectory/PackageToBuild/PackageToBuild.nuproj
@@ -11,20 +11,20 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>6a1ca851-c20e-4d96-a185-c8d8a99dfb47</ProjectGuid>
+    <ProjectGuid>7099a0bc-4369-47cd-b3e7-6441bb1ce293</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup>
     <NuProjPath Condition=" '$(NuProjPath)' == '' ">$(MSBuildExtensionsPath)\NuProj\</NuProjPath>
   </PropertyGroup>
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
-    <Id>Dependent.nuget</Id>
+    <Id>PackageToBuild</Id>
     <Version>1.0.0</Version>
-    <Title>Dependent</Title>
+    <Title>Package</Title>
     <Authors>kovalikp</Authors>
     <Owners>kovalikp</Owners>
-    <Summary>Dependent</Summary>
-    <Description>Dependent</Description>
+    <Summary>PackageToBuild</Summary>
+    <Description>PackageToBuild</Description>
     <ReleaseNotes>
     </ReleaseNotes>
     <ProjectUrl>
@@ -32,15 +32,12 @@
     <LicenseUrl>
     </LicenseUrl>
     <Copyright>Copyright © kovalikp</Copyright>
-    <Tags>Dependent</Tags>
+    <Tags>PackageToBuild</Tags>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="Readme.txt" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Dependency.nuget\Dependency.nuget.nuproj" />
-    <ProjectReference Include="..\Dependent\Dependent.net40.csproj" />
-    <ProjectReference Include="..\Dependent\Dependent.net45.csproj" />
+    <ProjectReference Include="..\Tool\Tool.csproj">
+      <PackageDirectory>Build</PackageDirectory>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(NuProjPath)\NuProj.targets" />
 </Project>

--- a/src/NuProj.Tests/Scenarios/References_PackageDirectory/PackageToContent/PackageToContent.nuproj
+++ b/src/NuProj.Tests/Scenarios/References_PackageDirectory/PackageToContent/PackageToContent.nuproj
@@ -11,20 +11,20 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>6a1ca851-c20e-4d96-a185-c8d8a99dfb47</ProjectGuid>
+    <ProjectGuid>fa625168-697c-44a8-ba9c-4a1577570c1d</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup>
     <NuProjPath Condition=" '$(NuProjPath)' == '' ">$(MSBuildExtensionsPath)\NuProj\</NuProjPath>
   </PropertyGroup>
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
-    <Id>Dependent.nuget</Id>
+    <Id>PackageToContent</Id>
     <Version>1.0.0</Version>
-    <Title>Dependent</Title>
+    <Title>PackageToContent</Title>
     <Authors>kovalikp</Authors>
     <Owners>kovalikp</Owners>
-    <Summary>Dependent</Summary>
-    <Description>Dependent</Description>
+    <Summary>PackageToContent</Summary>
+    <Description>PackageToContent</Description>
     <ReleaseNotes>
     </ReleaseNotes>
     <ProjectUrl>
@@ -32,15 +32,12 @@
     <LicenseUrl>
     </LicenseUrl>
     <Copyright>Copyright © kovalikp</Copyright>
-    <Tags>Dependent</Tags>
+    <Tags>PackageToContent</Tags>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="Readme.txt" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Dependency.nuget\Dependency.nuget.nuproj" />
-    <ProjectReference Include="..\Dependent\Dependent.net40.csproj" />
-    <ProjectReference Include="..\Dependent\Dependent.net45.csproj" />
+    <ProjectReference Include="..\Tool\Tool.csproj">
+      <PackageDirectory>Content</PackageDirectory>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(NuProjPath)\NuProj.targets" />
 </Project>

--- a/src/NuProj.Tests/Scenarios/References_PackageDirectory/PackageToLib/PackageToLib.nuproj
+++ b/src/NuProj.Tests/Scenarios/References_PackageDirectory/PackageToLib/PackageToLib.nuproj
@@ -11,20 +11,20 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>6a1ca851-c20e-4d96-a185-c8d8a99dfb47</ProjectGuid>
+    <ProjectGuid>704d72f9-fd96-42d3-961c-636d33411a06</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup>
     <NuProjPath Condition=" '$(NuProjPath)' == '' ">$(MSBuildExtensionsPath)\NuProj\</NuProjPath>
   </PropertyGroup>
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
-    <Id>Dependent.nuget</Id>
+    <Id>PackageToLib</Id>
     <Version>1.0.0</Version>
-    <Title>Dependent</Title>
+    <Title>PackageToLib</Title>
     <Authors>kovalikp</Authors>
     <Owners>kovalikp</Owners>
-    <Summary>Dependent</Summary>
-    <Description>Dependent</Description>
+    <Summary>PackageToLib</Summary>
+    <Description>PackageToLib</Description>
     <ReleaseNotes>
     </ReleaseNotes>
     <ProjectUrl>
@@ -32,15 +32,12 @@
     <LicenseUrl>
     </LicenseUrl>
     <Copyright>Copyright © kovalikp</Copyright>
-    <Tags>Dependent</Tags>
+    <Tags>PackageToLib</Tags>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="Readme.txt" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Dependency.nuget\Dependency.nuget.nuproj" />
-    <ProjectReference Include="..\Dependent\Dependent.net40.csproj" />
-    <ProjectReference Include="..\Dependent\Dependent.net45.csproj" />
+    <ProjectReference Include="..\Tool\Tool.csproj">
+      <PackageDirectory>Libraries</PackageDirectory>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(NuProjPath)\NuProj.targets" />
 </Project>

--- a/src/NuProj.Tests/Scenarios/References_PackageDirectory/PackageToLib/PackageToLib.nuproj
+++ b/src/NuProj.Tests/Scenarios/References_PackageDirectory/PackageToLib/PackageToLib.nuproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tool\Tool.csproj">
-      <PackageDirectory>Libraries</PackageDirectory>
+      <PackageDirectory>Lib</PackageDirectory>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(NuProjPath)\NuProj.targets" />

--- a/src/NuProj.Tests/Scenarios/References_PackageDirectory/PackageToRoot/PackageToRoot.nuproj
+++ b/src/NuProj.Tests/Scenarios/References_PackageDirectory/PackageToRoot/PackageToRoot.nuproj
@@ -11,20 +11,20 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>6a1ca851-c20e-4d96-a185-c8d8a99dfb47</ProjectGuid>
+    <ProjectGuid>d9ca4431-bfd8-4e53-b3f5-e2c9981435a9</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup>
     <NuProjPath Condition=" '$(NuProjPath)' == '' ">$(MSBuildExtensionsPath)\NuProj\</NuProjPath>
   </PropertyGroup>
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
-    <Id>Dependent.nuget</Id>
+    <Id>PackageToRoot</Id>
     <Version>1.0.0</Version>
-    <Title>Dependent</Title>
+    <Title>PackageToRoot</Title>
     <Authors>kovalikp</Authors>
     <Owners>kovalikp</Owners>
-    <Summary>Dependent</Summary>
-    <Description>Dependent</Description>
+    <Summary>PackageToRoot</Summary>
+    <Description>PackageToRoot</Description>
     <ReleaseNotes>
     </ReleaseNotes>
     <ProjectUrl>
@@ -32,15 +32,13 @@
     <LicenseUrl>
     </LicenseUrl>
     <Copyright>Copyright © kovalikp</Copyright>
-    <Tags>Dependent</Tags>
+    <Tags>PackageToRoot</Tags>
+    <GenerateSymbolPackage>false</GenerateSymbolPackage>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="Readme.txt" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Dependency.nuget\Dependency.nuget.nuproj" />
-    <ProjectReference Include="..\Dependent\Dependent.net40.csproj" />
-    <ProjectReference Include="..\Dependent\Dependent.net45.csproj" />
+    <ProjectReference Include="..\Tool\Tool.csproj">
+      <PackageDirectory>Root</PackageDirectory>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(NuProjPath)\NuProj.targets" />
 </Project>

--- a/src/NuProj.Tests/Scenarios/References_PackageDirectory/PackageToTools/PackageToTools.nuproj
+++ b/src/NuProj.Tests/Scenarios/References_PackageDirectory/PackageToTools/PackageToTools.nuproj
@@ -11,20 +11,20 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>6a1ca851-c20e-4d96-a185-c8d8a99dfb47</ProjectGuid>
+    <ProjectGuid>01e124f7-1156-43d1-af42-a2ec8e07eecf</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup>
     <NuProjPath Condition=" '$(NuProjPath)' == '' ">$(MSBuildExtensionsPath)\NuProj\</NuProjPath>
   </PropertyGroup>
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
-    <Id>Dependent.nuget</Id>
+    <Id>PackageToTools</Id>
     <Version>1.0.0</Version>
-    <Title>Dependent</Title>
+    <Title>Package</Title>
     <Authors>kovalikp</Authors>
     <Owners>kovalikp</Owners>
-    <Summary>Dependent</Summary>
-    <Description>Dependent</Description>
+    <Summary>PackageToTools</Summary>
+    <Description>PackageToTools</Description>
     <ReleaseNotes>
     </ReleaseNotes>
     <ProjectUrl>
@@ -32,15 +32,12 @@
     <LicenseUrl>
     </LicenseUrl>
     <Copyright>Copyright © kovalikp</Copyright>
-    <Tags>Dependent</Tags>
+    <Tags>PackageToTools</Tags>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="Readme.txt" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Dependency.nuget\Dependency.nuget.nuproj" />
-    <ProjectReference Include="..\Dependent\Dependent.net40.csproj" />
-    <ProjectReference Include="..\Dependent\Dependent.net45.csproj" />
+    <ProjectReference Include="..\Tool\Tool.csproj">
+      <PackageDirectory>Tools</PackageDirectory>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(NuProjPath)\NuProj.targets" />
 </Project>

--- a/src/NuProj.Tests/Scenarios/References_PackageDirectory/References_PackageDirectory.sln
+++ b/src/NuProj.Tests/Scenarios/References_PackageDirectory/References_PackageDirectory.sln
@@ -21,6 +21,10 @@ Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "PackageToContent", "Package
 EndProject
 Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "PackageToRoot", "PackageToRoot\PackageToRoot.nuproj", "{D9CA4431-BFD8-4E53-B3F5-E2C9981435A9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ToolWithDependency", "ToolWithDependency\ToolWithDependency.csproj", "{0F8881D7-6989-41E0-931D-BC02AEEF2DD9}"
+EndProject
+Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "PackageNuGetDependencyToTools", "PackageNuGetDependencyToTools\PackageNuGetDependencyToTools.nuproj", "{D8930C85-E974-4CAF-8A93-716EEAE3B98B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -63,6 +67,14 @@ Global
 		{D9CA4431-BFD8-4E53-B3F5-E2C9981435A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9CA4431-BFD8-4E53-B3F5-E2C9981435A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9CA4431-BFD8-4E53-B3F5-E2C9981435A9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0F8881D7-6989-41E0-931D-BC02AEEF2DD9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F8881D7-6989-41E0-931D-BC02AEEF2DD9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F8881D7-6989-41E0-931D-BC02AEEF2DD9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F8881D7-6989-41E0-931D-BC02AEEF2DD9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D8930C85-E974-4CAF-8A93-716EEAE3B98B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D8930C85-E974-4CAF-8A93-716EEAE3B98B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D8930C85-E974-4CAF-8A93-716EEAE3B98B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D8930C85-E974-4CAF-8A93-716EEAE3B98B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NuProj.Tests/Scenarios/References_PackageDirectory/References_PackageDirectory.sln
+++ b/src/NuProj.Tests/Scenarios/References_PackageDirectory/References_PackageDirectory.sln
@@ -1,0 +1,70 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tool", "Tool\Tool.csproj", "{C2CBEBA4-372E-4D10-8B7C-91F6D3484CB9}"
+EndProject
+Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "PackageDependencyToTools", "PackageDependencyToTools\PackageDependencyToTools.nuproj", "{57396CEA-46E7-49DF-BFA6-5DD5D9141108}"
+EndProject
+Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "PackageClosureToTools", "PackageClosureToTools\PackageClosureToTools.nuproj", "{2ED4F53C-67D7-457A-88D9-B91FE44B40A3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ToolWithClosure", "ToolWithClosure\ToolWithClosure.csproj", "{20428851-776E-4DB7-BBDD-48A4A6D51002}"
+EndProject
+Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "PackageToTools", "PackageToTools\PackageToTools.nuproj", "{01E124F7-1156-43D1-AF42-A2EC8E07EECF}"
+EndProject
+Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "PackageToBuild", "PackageToBuild\PackageToBuild.nuproj", "{7099A0BC-4369-47CD-B3E7-6441BB1CE293}"
+EndProject
+Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "PackageToLib", "PackageToLib\PackageToLib.nuproj", "{704D72F9-FD96-42D3-961C-636D33411A06}"
+EndProject
+Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "PackageToContent", "PackageToContent\PackageToContent.nuproj", "{FA625168-697C-44A8-BA9C-4A1577570C1D}"
+EndProject
+Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "PackageToRoot", "PackageToRoot\PackageToRoot.nuproj", "{D9CA4431-BFD8-4E53-B3F5-E2C9981435A9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C2CBEBA4-372E-4D10-8B7C-91F6D3484CB9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C2CBEBA4-372E-4D10-8B7C-91F6D3484CB9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C2CBEBA4-372E-4D10-8B7C-91F6D3484CB9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C2CBEBA4-372E-4D10-8B7C-91F6D3484CB9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{57396CEA-46E7-49DF-BFA6-5DD5D9141108}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{57396CEA-46E7-49DF-BFA6-5DD5D9141108}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{57396CEA-46E7-49DF-BFA6-5DD5D9141108}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{57396CEA-46E7-49DF-BFA6-5DD5D9141108}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2ED4F53C-67D7-457A-88D9-B91FE44B40A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2ED4F53C-67D7-457A-88D9-B91FE44B40A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2ED4F53C-67D7-457A-88D9-B91FE44B40A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2ED4F53C-67D7-457A-88D9-B91FE44B40A3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{20428851-776E-4DB7-BBDD-48A4A6D51002}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{20428851-776E-4DB7-BBDD-48A4A6D51002}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{20428851-776E-4DB7-BBDD-48A4A6D51002}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{20428851-776E-4DB7-BBDD-48A4A6D51002}.Release|Any CPU.Build.0 = Release|Any CPU
+		{01E124F7-1156-43D1-AF42-A2EC8E07EECF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{01E124F7-1156-43D1-AF42-A2EC8E07EECF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{01E124F7-1156-43D1-AF42-A2EC8E07EECF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{01E124F7-1156-43D1-AF42-A2EC8E07EECF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7099A0BC-4369-47CD-B3E7-6441BB1CE293}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7099A0BC-4369-47CD-B3E7-6441BB1CE293}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7099A0BC-4369-47CD-B3E7-6441BB1CE293}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7099A0BC-4369-47CD-B3E7-6441BB1CE293}.Release|Any CPU.Build.0 = Release|Any CPU
+		{704D72F9-FD96-42D3-961C-636D33411A06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{704D72F9-FD96-42D3-961C-636D33411A06}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{704D72F9-FD96-42D3-961C-636D33411A06}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{704D72F9-FD96-42D3-961C-636D33411A06}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FA625168-697C-44A8-BA9C-4A1577570C1D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FA625168-697C-44A8-BA9C-4A1577570C1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FA625168-697C-44A8-BA9C-4A1577570C1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FA625168-697C-44A8-BA9C-4A1577570C1D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D9CA4431-BFD8-4E53-B3F5-E2C9981435A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9CA4431-BFD8-4E53-B3F5-E2C9981435A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9CA4431-BFD8-4E53-B3F5-E2C9981435A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9CA4431-BFD8-4E53-B3F5-E2C9981435A9}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/NuProj.Tests/Scenarios/References_PackageDirectory/Tool/Class1.cs
+++ b/src/NuProj.Tests/Scenarios/References_PackageDirectory/Tool/Class1.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Tool
+{
+    public class Class1
+    {
+        public static void Do()
+        {
+        }
+    }
+}

--- a/src/NuProj.Tests/Scenarios/References_PackageDirectory/Tool/Properties/AssemblyInfo.cs
+++ b/src/NuProj.Tests/Scenarios/References_PackageDirectory/Tool/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Tool")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Tool")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("5449b8f2-d5a2-4192-bec6-90753b02f5b4")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NuProj.Tests/Scenarios/References_PackageDirectory/Tool/Tool.csproj
+++ b/src/NuProj.Tests/Scenarios/References_PackageDirectory/Tool/Tool.csproj
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C2CBEBA4-372E-4D10-8B7C-91F6D3484CB9}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Tool</RootNamespace>
+    <AssemblyName>Tool</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Class1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/NuProj.Tests/Scenarios/References_PackageDirectory/ToolWithClosure/Class1.cs
+++ b/src/NuProj.Tests/Scenarios/References_PackageDirectory/ToolWithClosure/Class1.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ToolWithClosure
+{
+    public class Class1
+    {
+        public static void Do()
+        {
+            Tool.Class1.Do();
+        }
+    }
+}

--- a/src/NuProj.Tests/Scenarios/References_PackageDirectory/ToolWithClosure/Properties/AssemblyInfo.cs
+++ b/src/NuProj.Tests/Scenarios/References_PackageDirectory/ToolWithClosure/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ToolWithClosure")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ToolWithClosure")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("116cf4dc-09ea-4187-ae94-1929662ce136")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NuProj.Tests/Scenarios/References_PackageDirectory/ToolWithClosure/ToolWithClosure.csproj
+++ b/src/NuProj.Tests/Scenarios/References_PackageDirectory/ToolWithClosure/ToolWithClosure.csproj
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{20428851-776E-4DB7-BBDD-48A4A6D51002}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ToolWithClosure</RootNamespace>
+    <AssemblyName>ToolWithClosure</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Class1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Tool\Tool.csproj">
+      <Project>{c2cbeba4-372e-4d10-8b7c-91f6d3484cb9}</Project>
+      <Name>Tool</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/NuProj.Tests/Scenarios/References_PackageDirectory/ToolWithDependency/Class1.cs
+++ b/src/NuProj.Tests/Scenarios/References_PackageDirectory/ToolWithDependency/Class1.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Immutable;
+
+namespace ToolWithDependency
+{
+    public class Class1
+    {
+        public void Foo()
+        {
+            var immutableList = ImmutableList.Create<int>();
+        }
+    }
+}

--- a/src/NuProj.Tests/Scenarios/References_PackageDirectory/ToolWithDependency/Properties/AssemblyInfo.cs
+++ b/src/NuProj.Tests/Scenarios/References_PackageDirectory/ToolWithDependency/Properties/AssemblyInfo.cs
@@ -1,17 +1,16 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Xunit;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("NuProj.Tests")]
+[assembly: AssemblyTitle("ToolWithDependency")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("NuProj.Tests")]
-[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyProduct("ToolWithDependency")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -21,7 +20,7 @@ using Xunit;
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("4007cf8c-006f-4451-892f-a3480e8b5154")]
+[assembly: Guid("894035ea-ae15-4721-ac8f-9eba23cd7540")]
 
 // Version information for an assembly consists of the following four values:
 //
@@ -35,6 +34,3 @@ using Xunit;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-
-// Disable xUnit paralellism settings, because multiple tests can work with same scenario.
-[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/src/NuProj.Tests/Scenarios/References_PackageDirectory/ToolWithDependency/ToolWithDependency.csproj
+++ b/src/NuProj.Tests/Scenarios/References_PackageDirectory/ToolWithDependency/ToolWithDependency.csproj
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{0F8881D7-6989-41E0-931D-BC02AEEF2DD9}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ToolWithDependency</RootNamespace>
+    <AssemblyName>ToolWithDependency</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.0.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Immutable.1.0.34\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Class1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/NuProj.Tests/Scenarios/References_PackageDirectory/ToolWithDependency/packages.config
+++ b/src/NuProj.Tests/Scenarios/References_PackageDirectory/ToolWithDependency/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Bcl.Immutable" version="1.0.34" targetFramework="net451" />
+</packages>

--- a/src/NuProj.sln
+++ b/src/NuProj.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuProj.Tasks", "NuProj.Tasks\NuProj.Tasks.csproj", "{187C3685-1EC7-4DCE-933B-8F7A43D5A481}"
 EndProject


### PR DESCRIPTION
`ProjectReference` items can output to other package folders,
like tools or build based on `PackageDirectory` metadata. (resolving #26) 

Using `Content` only items instead `Library` and `Tool` items. (as mentioned in #40)
