### PR TITLE
Allow GenerateNuSpec task required parameters to be taken from nuspec template file

### DIFF
--- a/src/NuProj.Targets/NuProj.targets
+++ b/src/NuProj.Targets/NuProj.targets
@@ -4,26 +4,6 @@
   <Import Project="$(CustomBeforeNuProjTargets)" Condition="'$(CustomBeforeNuProjTargets)' != '' and Exists('$(CustomBeforeNuProjTargets)')"/>
 
   <!--
-      NUSPEC PATH
-  -->
-
-  <PropertyGroup>
-    <NuSpecPath>$(IntermediateOutputPath)$(Id).nuspec</NuSpecPath>
-  </PropertyGroup>
-
-  <!--
-      OUTPUT PATHS
-
-      These properties aren't passed to NuGet.exe - they're implicit. However, we need to know the output paths
-      at several occasions (e.g. incremental build or clean up) so we want a central spot to capture those.
-  -->
-
-  <PropertyGroup>
-    <NuGetOutputPath>$([System.IO.Path]::GetFullPath('$(OutDir)$(Id).$(Version).nupkg'))</NuGetOutputPath>
-    <NuGetSymbolsOutputPath>$(OutDir)$(Id).$(Version).symbols.nupkg</NuGetSymbolsOutputPath>
-  </PropertyGroup>
-
-  <!--
       Properties relevant to Visual Studio:
 
       $(BuildingInsideVisualStudio)       This will indicate whether this project is building inside the IDE. When
@@ -109,6 +89,81 @@
   <UsingTask AssemblyFile="$(NuProjTasksPath)" TaskName="ReadPackagesConfig" />
   <UsingTask AssemblyFile="$(NuProjTasksPath)" TaskName="ReadPdbSourceFiles" />
   <UsingTask AssemblyFile="$(NuProjTasksPath)" TaskName="AssignSourceTargetPaths" />
+
+  <!--
+    ===================================================================================================================
+    _GetNuspecRequiredProperties
+    ===================================================================================================================
+    
+    This target ensures the Id and Version properties have assigned values.
+    
+    OUTPUTS:
+        $(Id)                          The Id of the NuGet package.
+        $(Version)                     The Version of the NuGet package.
+        $(NuSpecPath)                  The path of the NuSpec file to output.
+        $(NuGetOutputPath)             The path of the generated NuGet package.
+        $(NuGetSymbolsOutputPath)      The path of the generated NuGet symbols package.
+        
+    =================================================================================================================== -->
+
+  <Target Name="_GetNuspecRequiredProperties">
+
+    <!-- Get Id property from template, if not defined as property. -->
+    <XmlPeek Condition="'$(Id)' == '' And Exists('$(NuSpecTemplate)')"
+             Namespaces="&lt;Namespace Prefix='x' Uri='http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' /&gt;"
+             XmlInputPath="$(NuSpecTemplate)"
+             Query="/x:package/x:metadata/x:id/text()">
+      <Output TaskParameter="Result" PropertyName="Id"/>
+    </XmlPeek>
+
+    <Error Condition="'$(Id)' == ''"
+           File="$(MSBuildProjectFile)"
+           Text="The 'Id' property cannot be empty or undefined." />
+
+    <!-- Get Version property from template, if not defined as property. -->
+    <XmlPeek Condition="'$(Version)' == '' And Exists('$(NuSpecTemplate)')"
+             Namespaces="&lt;Namespace Prefix='x' Uri='http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' /&gt;"
+             XmlInputPath="$(NuSpecTemplate)"
+             Query="/x:package/x:metadata/x:version/text()">
+      <Output TaskParameter="Result" PropertyName="Version"/>
+    </XmlPeek>
+
+    <Error Condition="'$(Version)' == ''"
+           File="$(MSBuildProjectFile)"
+           Text="The 'Version' property cannot be empty or undefined." />
+
+    <!-- Get Authors property from template, if not defined as property. -->
+    <XmlPeek Condition="'$(Authors)' == '' And Exists('$(NuSpecTemplate)')"
+             Namespaces="&lt;Namespace Prefix='x' Uri='http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' /&gt;"
+             XmlInputPath="$(NuSpecTemplate)"
+             Query="/x:package/x:metadata/x:authors/text()">
+      <Output TaskParameter="Result" PropertyName="Authors"/>
+    </XmlPeek>
+
+    <Error Condition="'$(Authors)' == ''"
+           File="$(MSBuildProjectFile)"
+           Text="The 'Authors' property cannot be empty or undefined." />
+
+    <!-- Get Description property from template, if not defined as property. -->
+    <XmlPeek Condition="'$(Description)' == '' And Exists('$(NuSpecTemplate)')"
+             Namespaces="&lt;Namespace Prefix='x' Uri='http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' /&gt;"
+             XmlInputPath="$(NuSpecTemplate)"
+             Query="/x:package/x:metadata/x:description/text()">
+      <Output TaskParameter="Result" PropertyName="Description"/>
+    </XmlPeek>
+
+    <Error Condition="'$(Description)' == ''"
+           File="$(MSBuildProjectFile)"
+           Text="The 'Description' property cannot be empty or undefined." />
+
+    <!-- Create properties based on Id and Version properties. -->
+    <PropertyGroup>
+      <NuSpecPath>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)$(Id).nuspec'))</NuSpecPath>
+      <NuGetOutputPath>$([System.IO.Path]::GetFullPath('$(OutDir)$(Id).$(Version).nupkg'))</NuGetOutputPath>
+      <NuGetSymbolsOutputPath>$([System.IO.Path]::GetFullPath('$(OutDir)$(Id).$(Version).symbols.nupkg'))</NuGetSymbolsOutputPath>
+    </PropertyGroup>
+
+  </Target>
 
   <!--
     ===================================================================================================================
@@ -392,7 +447,7 @@
     =================================================================================================================== -->
 
   <Target Name="GenerateNuSpec"
-          DependsOnTargets="GetPackageDependencies;GetPackageFiles;GetSourceFiles">
+          DependsOnTargets="_GetNuspecRequiredProperties;GetPackageDependencies;GetPackageFiles;GetSourceFiles">
     <!-- Please Note:
          In order to avoid incremental build issues this target will always run.
          However, the task will make sure that it doesn't touch the file if the
@@ -469,7 +524,7 @@
 
   <Target Name="GetPackageFiles"
           Returns="@(PackageFile)"
-          DependsOnTargets="GetFiles;GetFileDependencies">
+          DependsOnTargets="_GetNuspecRequiredProperties;GetFiles;GetFileDependencies">
 
       <ItemGroup>
         <!-- We need to ensure that package libraries occur only once in their intended target path.
@@ -802,6 +857,27 @@
       <_PackageIdentity Include="$(Id)">
         <Version>$(Version)</Version>
       </_PackageIdentity>
+    </ItemGroup>
+  </Target>
+
+  <!--
+    ===================================================================================================================
+    GetPackageOutputs
+    ===================================================================================================================
+
+    Returns an item group containing the path names of the nupkg files (possibly) generated by the build.
+    
+    OUTPUTS:
+      @(_PackageOutputs)            The items whose identities are the package outputs.
+
+    =================================================================================================================== -->
+
+  <Target Name="GetPackageOutputs"
+          Returns="@(_PackageOutputs)"
+          DependsOnTargets="_GetNuspecRequiredProperties">
+    <ItemGroup>
+      <_PackageOutputs Include="$(NuGetOutputPath)" />
+      <_PackageOutputs Include="$(NuGetSymbolsOutputPath)" />
     </ItemGroup>
   </Target>
 

--- a/src/NuProj.Targets/NuProj.targets
+++ b/src/NuProj.Targets/NuProj.targets
@@ -852,7 +852,8 @@
     =================================================================================================================== -->
 
   <Target Name="GetPackageIdentity"
-          Returns="@(_PackageIdentity)">
+          Returns="@(_PackageIdentity)"
+          DependsOnTargets="_GetNuspecRequiredProperties">
     <ItemGroup>
       <_PackageIdentity Include="$(Id)">
         <Version>$(Version)</Version>

--- a/src/NuProj.Targets/NuProj.targets
+++ b/src/NuProj.Targets/NuProj.targets
@@ -197,81 +197,6 @@
 
   <!--
     ===================================================================================================================
-    _GetNuspecRequiredProperties
-    ===================================================================================================================
-    
-    This target ensures the Id and Version properties have assigned values.
-    
-    OUTPUTS:
-        $(Id)                          The Id of the NuGet package.
-        $(Version)                     The Version of the NuGet package.
-        $(NuSpecPath)                  The path of the NuSpec file to output.
-        $(NuGetOutputPath)             The path of the generated NuGet package.
-        $(NuGetSymbolsOutputPath)      The path of the generated NuGet symbols package.
-        
-    =================================================================================================================== -->
-
-  <Target Name="_GetNuspecRequiredProperties">
-
-    <!-- Get Id property from template, if not defined as property. -->
-    <XmlPeek Condition="'$(Id)' == '' And Exists('$(NuSpecTemplate)')"
-             Namespaces="&lt;Namespace Prefix='x' Uri='http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' /&gt;"
-             XmlInputPath="$(NuSpecTemplate)"
-             Query="/x:package/x:metadata/x:id/text()">
-      <Output TaskParameter="Result" PropertyName="Id"/>
-    </XmlPeek>
-
-    <Error Condition="'$(Id)' == ''"
-           File="$(MSBuildProjectFile)"
-           Text="The 'Id' property cannot be empty or undefined." />
-
-    <!-- Get Version property from template, if not defined as property. -->
-    <XmlPeek Condition="'$(Version)' == '' And Exists('$(NuSpecTemplate)')"
-             Namespaces="&lt;Namespace Prefix='x' Uri='http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' /&gt;"
-             XmlInputPath="$(NuSpecTemplate)"
-             Query="/x:package/x:metadata/x:version/text()">
-      <Output TaskParameter="Result" PropertyName="Version"/>
-    </XmlPeek>
-
-    <Error Condition="'$(Version)' == ''"
-           File="$(MSBuildProjectFile)"
-           Text="The 'Version' property cannot be empty or undefined." />
-
-    <!-- Get Authors property from template, if not defined as property. -->
-    <XmlPeek Condition="'$(Authors)' == '' And Exists('$(NuSpecTemplate)')"
-             Namespaces="&lt;Namespace Prefix='x' Uri='http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' /&gt;"
-             XmlInputPath="$(NuSpecTemplate)"
-             Query="/x:package/x:metadata/x:authors/text()">
-      <Output TaskParameter="Result" PropertyName="Authors"/>
-    </XmlPeek>
-
-    <Error Condition="'$(Authors)' == ''"
-           File="$(MSBuildProjectFile)"
-           Text="The 'Authors' property cannot be empty or undefined." />
-
-    <!-- Get Description property from template, if not defined as property. -->
-    <XmlPeek Condition="'$(Description)' == '' And Exists('$(NuSpecTemplate)')"
-             Namespaces="&lt;Namespace Prefix='x' Uri='http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' /&gt;"
-             XmlInputPath="$(NuSpecTemplate)"
-             Query="/x:package/x:metadata/x:description/text()">
-      <Output TaskParameter="Result" PropertyName="Description"/>
-    </XmlPeek>
-
-    <Error Condition="'$(Description)' == ''"
-           File="$(MSBuildProjectFile)"
-           Text="The 'Description' property cannot be empty or undefined." />
-
-    <!-- Create properties based on Id and Version properties. -->
-    <PropertyGroup>
-      <NuSpecPath>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)$(Id).nuspec'))</NuSpecPath>
-      <NuGetOutputPath>$([System.IO.Path]::GetFullPath('$(OutDir)$(Id).$(Version).nupkg'))</NuGetOutputPath>
-      <NuGetSymbolsOutputPath>$([System.IO.Path]::GetFullPath('$(OutDir)$(Id).$(Version).symbols.nupkg'))</NuGetSymbolsOutputPath>
-    </PropertyGroup>
-
-  </Target>
-
-  <!--
-    ===================================================================================================================
     _NuProjGetTemplateProperties
     ===================================================================================================================
     
@@ -346,7 +271,14 @@
     <CreateProperty Value="%(NuSpecProjectProperties.PropertyValue)">
       <Output TaskParameter="Value" PropertyName="%(Identity)" />      
     </CreateProperty>
-    
+
+    <!-- Create properties based on Id and Version properties. -->
+    <PropertyGroup>
+      <NuSpecPath Condition=" '$(NuSpecPath)' == '' ">$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)$(Id).nuspec'))</NuSpecPath>
+      <NuGetOutputPath Condition=" '$(NuGetOutputPath)' == '' ">$([System.IO.Path]::GetFullPath('$(OutDir)$(Id).$(Version).nupkg'))</NuGetOutputPath>
+      <NuGetSymbolsOutputPath Condition=" '$(NuGetSymbolsOutputPath)' == ''">$([System.IO.Path]::GetFullPath('$(OutDir)$(Id).$(Version).symbols.nupkg'))</NuGetSymbolsOutputPath>
+    </PropertyGroup>
+
   </Target>
   
   <!--
@@ -631,7 +563,7 @@
     =================================================================================================================== -->
 
   <Target Name="GenerateNuSpec"
-          DependsOnTargets="_GetNuspecRequiredProperties;GetPackageDependencies;GetPackageFiles;GetSourceFiles">
+          DependsOnTargets="_NuProjEnsureRequiredProperties;GetPackageDependencies;GetPackageFiles;GetSourceFiles">
     <!-- Please Note:
          In order to avoid incremental build issues this target will always run.
          However, the task will make sure that it doesn't touch the file if the
@@ -708,7 +640,7 @@
 
   <Target Name="GetPackageFiles"
           Returns="@(PackageFile)"
-          DependsOnTargets="_GetNuspecRequiredProperties;GetFiles;GetFileDependencies">
+          DependsOnTargets="_NuProjEnsureRequiredProperties;GetFiles;GetFileDependencies">
 
       <ItemGroup>
         <!-- We need to ensure that package libraries occur only once in their intended target path.
@@ -1037,7 +969,7 @@
 
   <Target Name="GetPackageIdentity"
           Returns="@(_PackageIdentity)"
-          DependsOnTargets="_GetNuspecRequiredProperties">
+          DependsOnTargets="_NuProjEnsureRequiredProperties">
     <ItemGroup>
       <_PackageIdentity Include="$(Id)">
         <Version>$(Version)</Version>
@@ -1059,7 +991,7 @@
 
   <Target Name="GetPackageOutputs"
           Returns="@(_PackageOutputs)"
-          DependsOnTargets="_GetNuspecRequiredProperties">
+          DependsOnTargets="_NuProjEnsureRequiredProperties">
     <ItemGroup>
       <_PackageOutputs Include="$(NuGetOutputPath)" />
       <_PackageOutputs Include="$(NuGetSymbolsOutputPath)" />

--- a/src/NuProj.Tasks/GenerateNuSpec.cs
+++ b/src/NuProj.Tasks/GenerateNuSpec.cs
@@ -21,22 +21,16 @@ namespace NuProj.Tasks
 
         public string MinClientVersion { get; set; }
 
-        [Required]
         public string Id { get; set; }
 
-        [Required]
         public string Version { get; set; }
 
-        [Required]
         public string Title { get; set; }
 
-        [Required]
         public string Authors { get; set; }
 
-        [Required]
         public string Owners { get; set; }
 
-        [Required]
         public string Description { get; set; }
 
         public string ReleaseNotes { get; set; }

--- a/src/NuProj.Tests/Infrastructure/MSBuild.cs
+++ b/src/NuProj.Tests/Infrastructure/MSBuild.cs
@@ -52,7 +52,7 @@ namespace NuProj.Tests.Infrastructure
                 buildManager.BeginBuild(parameters);
                 try
                 {
-                    var requestData = new BuildRequestData(projectPath, properties ?? Properties.Default, null, targetsToBuild, null);
+                    var requestData = new BuildRequestData(projectPath, properties ?? Properties.Default, null, targetsToBuild, null, BuildRequestDataFlags.ProvideProjectStateAfterBuild);
                     var submission = buildManager.PendBuildRequest(requestData);
                     result = await submission.ExecuteAsync();
                 }
@@ -172,6 +172,12 @@ namespace NuProj.Tests.Infrastructure
             {
                 Assert.False(ErrorEvents.Any(), ErrorEvents.Select(e => e.Message).FirstOrDefault());
                 Assert.Equal(BuildResultCode.Success, Result.OverallResult);
+            }
+
+            public void AssertError(string errorText, StringComparison comparisonType = StringComparison.OrdinalIgnoreCase)
+            {
+                Assert.True(ErrorEvents.Where(e => e.Message.IndexOf(errorText, comparisonType) >= 0).Any());
+                Assert.Equal(BuildResultCode.Failure, Result.OverallResult);
             }
         }
 

--- a/src/NuProj.Tests/Infrastructure/ProjectBuilder.cs
+++ b/src/NuProj.Tests/Infrastructure/ProjectBuilder.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
+using Xunit;
 
 namespace NuProj.Tests.Infrastructure
 {
@@ -50,7 +52,15 @@ namespace NuProj.Tests.Infrastructure
 
         public static string GetNuPkgPath(this Project nuProj)
         {
-            return nuProj.GetPropertyValue("NuGetOutputPath");
+            System.Collections.Generic.IDictionary<string, Microsoft.Build.Execution.TargetResult> targetResults;
+
+            var projectInstance = nuProj.CreateProjectInstance();
+            Assert.True(projectInstance.Build(new string[] { "GetPackageOutputs" },
+                                       null,
+                                       null,
+                                       out targetResults));
+
+            return targetResults.First().Value.Items.First().ItemSpec;
         }
     }
 }

--- a/src/NuProj.Tests/Scenarios/Task_GenerateNuSpec_NoRequiredParameters/ClassLibrary/Class1.cs
+++ b/src/NuProj.Tests/Scenarios/Task_GenerateNuSpec_NoRequiredParameters/ClassLibrary/Class1.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ClassLibrary
+{
+    public class Class1
+    {
+    }
+}

--- a/src/NuProj.Tests/Scenarios/Task_GenerateNuSpec_NoRequiredParameters/ClassLibrary/ClassLibrary.csproj
+++ b/src/NuProj.Tests/Scenarios/Task_GenerateNuSpec_NoRequiredParameters/ClassLibrary/ClassLibrary.csproj
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B48B6D77-CE87-4E33-8C7D-2B60E3A7CE30}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ClassLibrary</RootNamespace>
+    <AssemblyName>ClassLibrary</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Class1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/NuProj.Tests/Scenarios/Task_GenerateNuSpec_NoRequiredParameters/ClassLibrary/Properties/AssemblyInfo.cs
+++ b/src/NuProj.Tests/Scenarios/Task_GenerateNuSpec_NoRequiredParameters/ClassLibrary/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ClassLibrary")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ClassLibrary")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("9826f3eb-e428-4803-9950-749cc18f94b7")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NuProj.Tests/Scenarios/Task_GenerateNuSpec_NoRequiredParameters/NuGetPackage/NuGetPackage.nuproj
+++ b/src/NuProj.Tests/Scenarios/Task_GenerateNuSpec_NoRequiredParameters/NuGetPackage/NuGetPackage.nuproj
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|AnyCPU">
+      <Configuration>Debug</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|AnyCPU">
+      <Configuration>Release</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>79ce8c3e-25e3-4ee4-b0fe-8d66ddfa2187</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup>
+    <NuProjPath Condition=" '$(NuProjPath)' == '' ">$(MSBuildExtensionsPath)\NuProj\</NuProjPath>
+  </PropertyGroup>
+  <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
+  <PropertyGroup Label="Configuration">
+    <Id></Id>
+    <Version></Version>
+    <Title></Title>
+    <Authors></Authors>
+    <Owners></Owners>
+    <Summary>NuGetPackage</Summary>
+    <Description></Description>
+    <ReleaseNotes>
+    </ReleaseNotes>
+    <ProjectUrl>
+    </ProjectUrl>
+    <LicenseUrl>
+    </LicenseUrl>
+    <Copyright>Copyright © immol</Copyright>
+    <Tags>NuGetPackage</Tags>
+  </PropertyGroup>
+  <ItemGroup>
+    <Content Include="Readme.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ClassLibrary\ClassLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$(NuProjPath)\NuProj.targets" />
+</Project>

--- a/src/NuProj.Tests/Scenarios/Task_GenerateNuSpec_NoRequiredParameters/NuGetPackage/Readme.txt
+++ b/src/NuProj.Tests/Scenarios/Task_GenerateNuSpec_NoRequiredParameters/NuGetPackage/Readme.txt
@@ -1,0 +1,1 @@
+﻿This is your NuGet package.

--- a/src/NuProj.Tests/Scenarios/Task_GenerateNuSpec_NoRequiredParameters/NuGetPackage/template.nuspec
+++ b/src/NuProj.Tests/Scenarios/Task_GenerateNuSpec_NoRequiredParameters/NuGetPackage/template.nuspec
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>id</id>
+    <version>1.2.3</version>
+    <authors>authors</authors>
+    <description>description</description>
+  </metadata>
+</package>

--- a/src/NuProj.Tests/Scenarios/Task_GenerateNuSpec_NoRequiredParameters/Task_GenerateNuSpec_NoRequiredParameters.sln
+++ b/src/NuProj.Tests/Scenarios/Task_GenerateNuSpec_NoRequiredParameters/Task_GenerateNuSpec_NoRequiredParameters.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.30723.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassLibrary", "ClassLibrary\ClassLibrary.csproj", "{B48B6D77-CE87-4E33-8C7D-2B60E3A7CE30}"
+EndProject
+Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "NuGetPackage", "NuGetPackage\NuGetPackage.nuproj", "{79CE8C3E-25E3-4EE4-B0FE-8D66DDFA2187}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B48B6D77-CE87-4E33-8C7D-2B60E3A7CE30}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B48B6D77-CE87-4E33-8C7D-2B60E3A7CE30}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B48B6D77-CE87-4E33-8C7D-2B60E3A7CE30}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B48B6D77-CE87-4E33-8C7D-2B60E3A7CE30}.Release|Any CPU.Build.0 = Release|Any CPU
+		{79CE8C3E-25E3-4EE4-B0FE-8D66DDFA2187}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{79CE8C3E-25E3-4EE4-B0FE-8D66DDFA2187}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{79CE8C3E-25E3-4EE4-B0FE-8D66DDFA2187}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{79CE8C3E-25E3-4EE4-B0FE-8D66DDFA2187}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Issue #57 

Make Id, Version, Authors, and Description properties optional if specified in the nuspec template file.
