### PR TITLE
Issue #59 - Track file writes across builds to ensure proper cleaning.

### DIFF
--- a/src/NuProj.Targets/NuProj.targets
+++ b/src/NuProj.Targets/NuProj.targets
@@ -55,6 +55,11 @@
     <BuildProjectReferences Condition="'$(BuildProjectReferences)' == ''">true</BuildProjectReferences>
   </PropertyGroup>
 
+  <!-- CleanFile is used to track file writes between builds. -->
+  <PropertyGroup>
+    <CleanFile Condition="'$(CleanFile)'==''">$(MSBuildProjectFile).FileListAbsolute.txt</CleanFile>
+  </PropertyGroup>
+
   <!--
       MSBuildAllProjects is used to keep track of all projects the build depends on.
       We make all targets depending on it to make sure everything rebuilds.
@@ -421,6 +426,12 @@
                     References="@(Reference)"
                     FrameworkReferences="@(FrameworkReference)"
                     Files="@(PackageFile)"/>
+
+    <!-- Include the $(NuSpecPath) file in the group of written files. -->
+    <ItemGroup>
+      <FileWrites Include="$(NuSpecPath)" />
+    </ItemGroup>
+
   </Target>
 
   <!--
@@ -452,6 +463,11 @@
                ToolPath="$(NuGetToolPath)"
                ToolExe="$(NuGetToolExe)"
                NuSpecPath="$(NuSpecPath)"/>
+    <!-- Include nuget packages in written files. -->
+    <ItemGroup>
+      <FileWrites Include="$(NuGetOutputPath)" />
+      <FileWrites Include="$(NuGetSymbolsOutputPath)" Condition="Exists('$(NuGetSymbolsOutputPath)')"/>
+    </ItemGroup>
   </Target>
 
   <!--
@@ -807,6 +823,123 @@
 
   <!--
     ===================================================================================================================
+    Incremental Clean
+    
+    Remove files produced from previous builds, but were not produced in the current build. 
+    
+    =================================================================================================================== -->
+
+  <Target Name="IncrementalClean"
+          DependsOnTargets="_CleanGetCurrentAndPriorFileWrites">
+
+    <!-- Remove files built in prior builds from the list of files built in this build. -->
+    <ItemGroup>
+      <_CleanOrphanFileWrites Include="@(_CleanPriorFileWrites)" Exclude="@(_CleanCurrentFileWrites)" />
+    </ItemGroup>
+
+    <!-- Find all files in the final output directory. -->
+    <FindUnderPath Path="$(OutDir)" Files="@(_CleanOrphanFileWrites)">
+      <Output TaskParameter="InPath" ItemName="_CleanOrphanFileWritesInOutput"/>
+    </FindUnderPath>
+
+    <!-- Find all files in the intermediate output directory. -->
+    <FindUnderPath Path="$(IntermediateOutputPath)" Files="@(_CleanOrphanFileWrites)">
+      <Output TaskParameter="InPath" ItemName="_CleanOrphanFileWritesInIntermediate"/>
+    </FindUnderPath>
+
+    <!-- Delete the orphaned files. -->
+    <Delete
+        Files="@(_CleanOrphanFileWritesInIntermediate);@(_CleanOrphanFileWritesInOutput)"
+        TreatErrorsAsWarnings="true">
+      <Output TaskParameter="DeletedFiles" ItemName="_CleanOrphanFilesDeleted"/>
+    </Delete>
+
+    <!-- Create a list of everything that wasn't deleted or was outside
+             the current final output and intermediate output directories. -->
+    <ItemGroup>
+      <_CleanRemainingFileWritesAfterIncrementalClean Include="@(_CleanPriorFileWrites);@(_CleanCurrentFileWrites)" Exclude="@(_CleanOrphanFilesDeleted)"/>
+    </ItemGroup>
+
+    <!-- Remove duplicates. -->
+    <RemoveDuplicates Inputs="@(_CleanRemainingFileWritesAfterIncrementalClean)">
+      <Output TaskParameter="Filtered" ItemName="_CleanUniqueRemainingFileWritesAfterIncrementalClean"/>
+    </RemoveDuplicates>
+
+    <!-- Write new list of current files back to disk, replacing the existing list.-->
+    <WriteLinesToFile
+        File="$(IntermediateOutputPath)$(CleanFile)"
+        Lines="@(_CleanUniqueRemainingFileWritesAfterIncrementalClean)"
+        Condition="'@(_CleanUnfilteredPriorFileWrites)'!='@(_CleanUniqueRemainingFileWritesAfterIncrementalClean)'"
+        Overwrite="true"/>
+
+  </Target>
+
+  <!--
+    ===================================================================================================================
+    _CleanGetCurrentAndPriorFileWrites
+    =================================================================================================================== -->
+
+  <Target Name="_CleanGetCurrentAndPriorFileWrites">
+
+    <!-- Read the list of files produced by prior builds. -->
+    <ReadLinesFromFile File="$(IntermediateOutputPath)$(CleanFile)">
+      <Output TaskParameter="Lines" ItemName="_CleanUnfilteredPriorFileWrites"/>
+    </ReadLinesFromFile>
+
+    <ItemGroup>
+      <_CleanPriorFileWrites Include="@(_CleanUnfilteredPriorFileWrites)" />
+    </ItemGroup>
+
+    <!-- find all files in the final output directory -->
+    <FindUnderPath Path="$(OutDir)" Files="@(FileWrites)" UpdateToAbsolutePaths="true">
+      <Output TaskParameter="InPath" ItemName="_CleanCurrentFileWritesInOutput" />
+    </FindUnderPath>
+
+    <!-- find all files in the intermediate output directory -->
+    <FindUnderPath Path="$(IntermediateOutputPath)" Files="@(FileWrites)" UpdateToAbsolutePaths="true">
+      <Output TaskParameter="InPath" ItemName="_CleanCurrentFileWritesInIntermediate" />
+    </FindUnderPath>
+
+    <RemoveDuplicates Inputs="@(_CleanCurrentFileWritesInOutput);@(_CleanCurrentFileWritesInIntermediate)">
+      <Output TaskParameter="Filtered" ItemName="_CleanCurrentFileWrites"/>
+    </RemoveDuplicates>
+
+  </Target>
+
+  <!--
+    ============================================================
+                                        _CleanRecordFileWrites
+
+    Save the list of all files written to disk so that it can be used for "Clean" later.
+
+    Files written in prior builds are not removed from Clean cache.
+    ============================================================
+    -->
+  <Target
+       Name="_CleanRecordFileWrites"
+       DependsOnTargets="_CleanGetCurrentAndPriorFileWrites">
+
+    <!--
+        Merge list of files from prior builds with the current build and then
+        remove duplicates.
+        -->
+    <RemoveDuplicates Inputs="@(_CleanPriorFileWrites);@(_CleanCurrentFileWrites)">
+      <Output TaskParameter="Filtered" ItemName="_CleanUniqueFileWrites"/>
+    </RemoveDuplicates>
+
+    <!-- Make sure the directory exists. -->
+    <MakeDir Directories="$(IntermediateOutputPath)"/>
+
+    <!-- Write merged file list back to disk, replacing existing contents. -->
+    <WriteLinesToFile
+        File="$(IntermediateOutputPath)$(CleanFile)"
+        Lines="@(_CleanUniqueFileWrites)"
+        Overwrite="true" />
+
+  </Target>
+
+  <!--
+    ===================================================================================================================
     Clean, Build, Rebuild
     ===================================================================================================================
 
@@ -827,19 +960,52 @@
              Properties="$(ProjectProperties)" />
 
     <!-- Delete our outputs and intermediates. -->
+    <!-- Read in list of files that were written to disk in past builds. -->
+    <ReadLinesFromFile File="$(IntermediateOutputPath)$(CleanFile)">
+      <Output TaskParameter="Lines" ItemName="_CleanPriorFileWrites"/>
+    </ReadLinesFromFile>
 
+    <!-- Find all files in the final output directory. -->
+    <FindUnderPath Path="$(OutDir)" Files="@(_CleanPriorFileWrites)">
+      <Output TaskParameter="InPath" ItemName="_CleanPriorFileWritesInOutput"/>
+    </FindUnderPath>
+
+    <!-- Find all files in the intermediate output directory. -->
+    <FindUnderPath Path="$(IntermediateOutputPath)"    Files="@(_CleanPriorFileWrites)">
+      <Output TaskParameter="InPath" ItemName="_CleanPriorFileWritesInIntermediate"/>
+    </FindUnderPath>
+
+    <!-- Delete those files. -->
+    <Delete
+        Files="@(_CleanPriorFileWritesInOutput);@(_CleanPriorFileWritesInIntermediate)"
+        TreatErrorsAsWarnings="true">
+
+      <Output TaskParameter="DeletedFiles" ItemName="_CleanPriorFileWritesDeleted"/>
+
+    </Delete>
+
+    <!-- Create a list of everything that wasn't deleted. -->
     <ItemGroup>
-      <_ToBeDeleted Include="$(NuSpecPath)" />
-      <_ToBeDeleted Include="$(NuGetOutputPath)" />
-      <_ToBeDeleted Include="$(NuGetSymbolsOutputPath)" />
+      <_CleanRemainingFileWritesAfterClean Include="@(_CleanPriorFileWrites)" Exclude="@(_CleanPriorFileWritesDeleted)"/>
     </ItemGroup>
-    <Delete Files="@(_ToBeDeleted)" />
+
+    <!-- Remove duplicates. -->
+    <RemoveDuplicates Inputs="@(_CleanRemainingFileWritesAfterClean)">
+      <Output TaskParameter="Filtered" ItemName="_CleanUniqueRemainingFileWrites"/>
+    </RemoveDuplicates>
+
+    <!-- Make sure the directory exists. -->
+    <MakeDir Directories="$(IntermediateOutputPath)"/>
+
+    <!-- Write new list of current files back to disk. -->
+    <WriteLinesToFile File="$(IntermediateOutputPath)$(CleanFile)" Lines="@(_CleanUniqueRemainingFileWrites)" Overwrite="true" />
 
   </Target>
 
-  <Target Name="Build" DependsOnTargets="CreatePackage">
+  <Target Name="Build" DependsOnTargets="CreatePackage;IncrementalClean">
     <Message Text="$(MSBuildProjectName) -> $(NuGetOutputPath)"
              Importance="high" />
+    <OnError ExecuteTargets="_CleanRecordFileWrites" />
   </Target>
 
   <Target Name="Rebuild" DependsOnTargets="Clean;Build" />

--- a/src/NuProj.Targets/NuProj.targets
+++ b/src/NuProj.Targets/NuProj.targets
@@ -796,7 +796,7 @@
               ItemName="_SourceFileWithTargetPath" />
       <Output TaskParameter="SourceFilesWithTargetPath"
               ItemName="PackageFile" />
-    </AssignSourceTargetPaths>
+    </AssignSourceTargetPaths>  
   </Target>
 
   <!--

--- a/src/NuProj.Tests/Scenarios/IncrementalBuild_CleanOldProducts/ClassLibrary/Class1.cs
+++ b/src/NuProj.Tests/Scenarios/IncrementalBuild_CleanOldProducts/ClassLibrary/Class1.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ClassLibrary
+{
+    public class Class1
+    {
+    }
+}

--- a/src/NuProj.Tests/Scenarios/IncrementalBuild_CleanOldProducts/ClassLibrary/ClassLibrary.csproj
+++ b/src/NuProj.Tests/Scenarios/IncrementalBuild_CleanOldProducts/ClassLibrary/ClassLibrary.csproj
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B48B6D77-CE87-4E33-8C7D-2B60E3A7CE30}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ClassLibrary</RootNamespace>
+    <AssemblyName>ClassLibrary</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Class1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/NuProj.Tests/Scenarios/IncrementalBuild_CleanOldProducts/ClassLibrary/Properties/AssemblyInfo.cs
+++ b/src/NuProj.Tests/Scenarios/IncrementalBuild_CleanOldProducts/ClassLibrary/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ClassLibrary")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ClassLibrary")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("9826f3eb-e428-4803-9950-749cc18f94b7")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NuProj.Tests/Scenarios/IncrementalBuild_CleanOldProducts/IncrementalBuild_CleanOldProducts.sln
+++ b/src/NuProj.Tests/Scenarios/IncrementalBuild_CleanOldProducts/IncrementalBuild_CleanOldProducts.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.30723.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassLibrary", "ClassLibrary\ClassLibrary.csproj", "{B48B6D77-CE87-4E33-8C7D-2B60E3A7CE30}"
+EndProject
+Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "NuGetPackage", "NuGetPackage\NuGetPackage.nuproj", "{79CE8C3E-25E3-4EE4-B0FE-8D66DDFA2187}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B48B6D77-CE87-4E33-8C7D-2B60E3A7CE30}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B48B6D77-CE87-4E33-8C7D-2B60E3A7CE30}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B48B6D77-CE87-4E33-8C7D-2B60E3A7CE30}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B48B6D77-CE87-4E33-8C7D-2B60E3A7CE30}.Release|Any CPU.Build.0 = Release|Any CPU
+		{79CE8C3E-25E3-4EE4-B0FE-8D66DDFA2187}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{79CE8C3E-25E3-4EE4-B0FE-8D66DDFA2187}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{79CE8C3E-25E3-4EE4-B0FE-8D66DDFA2187}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{79CE8C3E-25E3-4EE4-B0FE-8D66DDFA2187}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/NuProj.Tests/Scenarios/IncrementalBuild_CleanOldProducts/NuGetPackage/NuGetPackage.nuproj
+++ b/src/NuProj.Tests/Scenarios/IncrementalBuild_CleanOldProducts/NuGetPackage/NuGetPackage.nuproj
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|AnyCPU">
+      <Configuration>Debug</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|AnyCPU">
+      <Configuration>Release</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>79ce8c3e-25e3-4ee4-b0fe-8d66ddfa2187</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup>
+    <NuProjPath Condition=" '$(NuProjPath)' == '' ">$(MSBuildExtensionsPath)\NuProj\</NuProjPath>
+  </PropertyGroup>
+  <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
+  <PropertyGroup Label="Configuration">
+    <Id>NuGetPackage</Id>
+    <Version>1.0.0</Version>
+    <Title>NuGetPackage</Title>
+    <Authors>immol</Authors>
+    <Owners>immol</Owners>
+    <Summary>NuGetPackage</Summary>
+    <Description>NuGetPackage</Description>
+    <ReleaseNotes>
+    </ReleaseNotes>
+    <ProjectUrl>
+    </ProjectUrl>
+    <LicenseUrl>
+    </LicenseUrl>
+    <Copyright>Copyright © immol</Copyright>
+    <Tags>NuGetPackage</Tags>
+  </PropertyGroup>
+  <ItemGroup>
+    <Content Include="Readme.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ClassLibrary\ClassLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$(NuProjPath)\NuProj.targets" />
+</Project>

--- a/src/NuProj.Tests/Scenarios/IncrementalBuild_CleanOldProducts/NuGetPackage/Readme.txt
+++ b/src/NuProj.Tests/Scenarios/IncrementalBuild_CleanOldProducts/NuGetPackage/Readme.txt
@@ -1,0 +1,1 @@
+﻿This is your NuGet package.


### PR DESCRIPTION
Store files written during build into FileListAbsolute.txt. Use previous build products and current build products to perform incremental clean during build and proper clean during Clean target. (Resolves issue #59)