### PR TITLE
Ignore .vs folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ syntax: glob
 # User-specific files
 *.user
 *.suo
+src/.vs
 
 # Build results
 bin


### PR DESCRIPTION
Dev14 moves a lot of no-SCC files into a new hidden .vs folder. Make git ignore it.