### PR TITLE
Preserve metadata on project references

### DIFF
--- a/src/NuProj.Targets/NuProj.targets
+++ b/src/NuProj.Targets/NuProj.targets
@@ -158,8 +158,8 @@
       <_ProjectReferenceClosure Include="@(_ProjectReferenceClosureWithoutMetadata)">
         <DependencyKind>Indirect</DependencyKind>
       </_ProjectReferenceClosure>
-      <!-- Now add the direct references -->
-      <_ProjectReferenceClosure Include="%(ProjectReference.FullPath)">
+      <!-- Now add the direct references, preserving metadata -->
+      <_ProjectReferenceClosure Include="@(ProjectReference->'%(FullPath)')">
         <DependencyKind>Direct</DependencyKind>
       </_ProjectReferenceClosure>
     </ItemGroup>


### PR DESCRIPTION
In our build we extend the expand project references and would like to have metadata flow to this point.