### PR TITLE
Configurable TargetFramework for project references.

### DIFF
--- a/docs/Authoring.md
+++ b/docs/Authoring.md
@@ -139,6 +139,19 @@ put into `lib` folder. The package directory can be controlled by using
 </ItemGroup>
 ```
 
+Target framework for referenced project will be resolved from project reference 
+itself. You can override this behavior using `TargetFramework` metadata.
+
+```xml
+<ItemGroup>
+  <!-- This will generate "tools\NuProj.Tasks.dll" target path. -->
+  <ProjectReference Include="..\NuProj.Tasks\NuProj.Tasks.csproj">
+    <PackageDirectory>Tools</PackageDirectory>
+    <TargetFramework></TargetFramework>
+  </ProjectReference>
+</ItemGroup>
+```
+
 You can also reference other NuProj projects to generate package dependencies.
 Content of `Lib` directory of `Dependency` package will be removed from `Lib` 
 directory of dependent package. `Dependency` package will be added as a NuGet 

--- a/src/NuProj.Package/Rules/ProjectReference.xaml
+++ b/src/NuProj.Package/Rules/ProjectReference.xaml
@@ -22,6 +22,36 @@
                   Description="The directory to receive the output of this reference.">
         <EnumValue Name="Lib" DisplayName="lib" />
         <EnumValue Name="Tools" DisplayName="tools" />
+        <EnumValue Name="Build" DisplayName="build" />
+    </EnumProperty>
+
+    <EnumProperty Name="TargetFramework"
+                  DisplayName="Target framework"
+                  Category="Advanced"
+                  Description="The subdirectory specifying target framework to receive the output of this reference.">
+        <EnumValue Name="TargetFrameworkMoniker" DisplayName="Detect Target Framework" Description="Resolves target framework from referenced project." />
+        <EnumValue Name="" DisplayName="Any Framework" Description="Does not create target framework subdirectory." />
+        <EnumValue Name="net10" DisplayName=".Net 1.0" />
+        <EnumValue Name="net11" DisplayName=".Net 1.1" />
+        <EnumValue Name="net20" DisplayName=".Net 2.0" />
+        <EnumValue Name="net30" DisplayName=".Net 3.0" />
+        <EnumValue Name="net35" DisplayName=".Net 3.5" />
+        <EnumValue Name="net40" DisplayName=".Net 4.0" />
+        <EnumValue Name="net40-full" DisplayName=".Net 4.0 (Full)" />
+        <EnumValue Name="net40-client" DisplayName=".Net 4.0 (Client)" />
+        <EnumValue Name="net40-cf" DisplayName=".Net 4.0 (Compact)" />
+        <EnumValue Name="net45" DisplayName=".Net 4.5" />
+        <EnumValue Name="net451" DisplayName=".Net 4.5.1" />
+        <EnumValue Name="net452" DisplayName=".Net 4.5.2" />
+        <EnumValue Name="sl1" DisplayName="Silverlight 1.0" />
+        <EnumValue Name="sl2" DisplayName="Silverlight 2.0" />
+        <EnumValue Name="sl3" DisplayName="Silverlight 3.0" />
+        <EnumValue Name="sl4" DisplayName="Silverlight 4.0" />
+        <EnumValue Name="sl5" DisplayName="Silverlight 5.0" />
+        <EnumValue Name="wp7" DisplayName="Windows Phone 7.0" />
+        <EnumValue Name="wp71" DisplayName="Windows Phone 7.1" />
+        <EnumValue Name="wpa" DisplayName="Windows Phone App" />
+        <EnumValue Name="windows8" DisplayName="Windows Store App" />
     </EnumProperty>
 
     <BoolProperty Name="ReferenceOutputAssembly"

--- a/src/NuProj.Packages/NuProj.nuproj
+++ b/src/NuProj.Packages/NuProj.nuproj
@@ -36,6 +36,7 @@ There is also a Visual Studio extension which you find under http://bit.ly/NuPro
   <ItemGroup>
     <ProjectReference Include="..\NuProj.Tasks\NuProj.Tasks.csproj">
       <PackageDirectory>Tools</PackageDirectory>
+      <TargetFramework></TargetFramework>
     </ProjectReference>
   </ItemGroup>
   

--- a/src/NuProj.Targets/NuProj.targets
+++ b/src/NuProj.Targets/NuProj.targets
@@ -134,13 +134,13 @@
   <PropertyGroup>
     <ProjectProperties>
       Configuration=$(Configuration);
-      Platform=$(Platform)
+      Platform=$(Platform);
     </ProjectProperties>
 
     <!-- Use 'Microsoft.Common.NuProj.targets' if it's in same directory as this script. 
          For example when using NuProj NuGet package instead of VS integration.-->
     <ProjectProperties Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.Common.NuProj.targets') And !$(CustomAfterMicrosoftCommonTargets.Contains('Microsoft.Common.NuProj.targets'))">
-      $(ProjectProperties);CustomAfterMicrosoftCommonTargets=$(MSBuildThisFileDirectory)Microsoft.Common.NuProj.targets
+      $(ProjectProperties)CustomAfterMicrosoftCommonTargets=$(MSBuildThisFileDirectory)Microsoft.Common.NuProj.targets
     </ProjectProperties>
   </PropertyGroup>
 
@@ -153,7 +153,7 @@
   <ItemDefinitionGroup>
     <ProjectReference>
       <PackageDirectory>Lib</PackageDirectory>
-      <TargetFramework></TargetFramework>
+      <TargetFramework>TargetFrameworkMoniker</TargetFramework>
     </ProjectReference>
   </ItemDefinitionGroup>
 
@@ -352,10 +352,15 @@
 
         <!-- In order to package the the files in the correct folder in the
              NuGet package we need need to know the target framework moniker. -->
+      
+        <PropertyGroup>
+          <_NonNuProjProjectTargetFrameworkMoniker></_NonNuProjProjectTargetFrameworkMoniker>
+        </PropertyGroup>
 
         <MSBuild Targets="GetTargetFrameworkMoniker"
                  Projects="@(_NonNuProjProjectReference)"
-                 Properties="$(ProjectProperties)">
+                 Properties="$(ProjectProperties)"
+                 Condition="'@(_NonNuProjProjectReference->'%(TargetFramework)')' == 'TargetFrameworkMoniker'">
           
             <Output TaskParameter="TargetOutputs"
                     PropertyName="_NonNuProjProjectTargetFrameworkMoniker" />

--- a/src/NuProj.Tasks/AssignTargetFramework.cs
+++ b/src/NuProj.Tasks/AssignTargetFramework.cs
@@ -33,9 +33,19 @@ namespace NuProj.Tasks
         private static ITaskItem ConvertToPackageFile(ITaskItem output)
         {
             var fileName = output.ItemSpec;
-            var frameworkNameMoniker = output.GetTargetFrameworkMoniker();
+            var targetFramework = "";
+            if (output.UseTargetFrameworkMoniker())
+            {
+                var frameworkNameMoniker = output.GetTargetFrameworkMoniker();
+                targetFramework = frameworkNameMoniker.GetShortFrameworkName();
+            }
+            else
+            {
+                var frameworkName = output.GetTargetFramework();
+                targetFramework = frameworkName.GetShortFrameworkName();
+            }
+
             var packageDirectory = output.GetPackageDirectory();
-            var targetFramework = frameworkNameMoniker.GetShortFrameworkName();
             var metadata = output.CloneCustomMetadata();
             metadata[Metadata.TargetFramework] = targetFramework;
             metadata[Metadata.PackageDirectory] = packageDirectory.ToString();

--- a/src/NuProj.Tests/ReferenceTests.cs
+++ b/src/NuProj.Tests/ReferenceTests.cs
@@ -54,14 +54,14 @@ namespace NuProj.Tests
         }
 
         [Theory]
-        [InlineData("PackageToBuild", new[] { @"build\Tool.dll" }, new string[0])]
+        [InlineData("PackageToBuild", new[] { @"build\net45\Tool.dll" }, new string[0])]
         [InlineData("PackageToLib", new[] { @"lib\net45\Tool.dll" }, new string[0])]
         [InlineData("PackageToRoot", new[] { @"Tool.dll", @"Tool.pdb" }, new string[0])]
-        [InlineData("PackageToTools", new[] { @"tools\Tool.dll" }, new string[0])]
-        [InlineData("PackageDependencyToTools", new[] { @"tools\Tool.dll" }, new[] { "PackageToTools (>= 1.0.0)" })]
-        [InlineData("PackageClosureToTools", new[] { @"tools\Tool.dll", @"tools\ToolWithClosure.dll" }, new string[0])]
+        [InlineData("PackageToTools", new[] { @"tools\net45\Tool.dll" }, new string[0])]
+        [InlineData("PackageDependencyToTools", new[] { @"tools\net45\Tool.dll" }, new[] { "PackageToTools (>= 1.0.0)" })]
+        [InlineData("PackageClosureToTools", new[] { @"tools\net45\Tool.dll", @"tools\net45\ToolWithClosure.dll" }, new string[0])]
         [InlineData("PackageToContent", new[] { @"content\Tool.dll", @"content\Tool.pdb" }, new string[0])]
-        [InlineData("PackageNuGetDependencyToTools", new[] { @"tools\System.Collections.Immutable.dll", @"tools\ToolWithDependency.dll" }, new string[0])]
+        [InlineData("PackageNuGetDependencyToTools", new[] { @"tools\net451\System.Collections.Immutable.dll", @"tools\net451\ToolWithDependency.dll" }, new string[0])]
         public async Task References_PackageDirectory_ToolIsPackaged(
             string packageId, 
             string[] expectedFiles, 
@@ -74,6 +74,18 @@ namespace NuProj.Tests
             expectedDependencies = expectedDependencies.OrderBy(x => x).ToArray();
             Assert.Equal(expectedFiles, actualFiles);
             Assert.Equal(expectedDependencies, actualDependencies);
+        }
+
+        [Theory]
+        [InlineData("TargetFramework45", new[] { @"lib\net45\Library.dll" })]
+        [InlineData("TargetFrameworkAny", new[] { @"lib\Library.dll" })]
+        [InlineData("TargetFrameworkMoniker", new[] { @"lib\net40\Library.dll" })]
+        public async Task References_TargetFramework_UsesMetadata(string packageId, string[] expectedFiles)
+        {
+            var package = await Scenario.RestoreAndBuildSinglePackageAsync("References_TargetFramework", packageId);
+            var actualFiles = package.GetFiles().Select(f => f.Path).OrderBy(x => x);
+            expectedFiles = expectedFiles.OrderBy(x => x).ToArray();
+            Assert.Equal(expectedFiles, actualFiles);
         }
     }
 }

--- a/src/NuProj.Tests/Scenarios/References_TargetFramework/Library/Class1.cs
+++ b/src/NuProj.Tests/Scenarios/References_TargetFramework/Library/Class1.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Library
+{
+    public class Class1
+    {
+    }
+}

--- a/src/NuProj.Tests/Scenarios/References_TargetFramework/Library/Library.csproj
+++ b/src/NuProj.Tests/Scenarios/References_TargetFramework/Library/Library.csproj
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{D24F7DB7-FBA6-4099-A9CA-E1D422C8A09F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Library</RootNamespace>
+    <AssemblyName>Library</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Class1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/NuProj.Tests/Scenarios/References_TargetFramework/Library/Properties/AssemblyInfo.cs
+++ b/src/NuProj.Tests/Scenarios/References_TargetFramework/Library/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Library")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Library")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("70cf1232-33bd-4439-b901-19edd72ae53e")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NuProj.Tests/Scenarios/References_TargetFramework/References_TargetFramework.sln
+++ b/src/NuProj.Tests/Scenarios/References_TargetFramework/References_TargetFramework.sln
@@ -1,0 +1,40 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Library", "Library\Library.csproj", "{D24F7DB7-FBA6-4099-A9CA-E1D422C8A09F}"
+EndProject
+Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "TargetFrameworkMoniker", "TargetFrameworkMoniker\TargetFrameworkMoniker.nuproj", "{E8601563-E736-42E8-BB7B-A56120E153BE}"
+EndProject
+Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "TargetFrameworkAny", "TargetFrameworkAny\TargetFrameworkAny.nuproj", "{6EE95575-4838-4769-8113-97ABD3686417}"
+EndProject
+Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "TargetFramework45", "TargetFramework45\TargetFramework45.nuproj", "{59D6182A-6801-42F8-BFB2-FDA9B3C2CC9F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D24F7DB7-FBA6-4099-A9CA-E1D422C8A09F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D24F7DB7-FBA6-4099-A9CA-E1D422C8A09F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D24F7DB7-FBA6-4099-A9CA-E1D422C8A09F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D24F7DB7-FBA6-4099-A9CA-E1D422C8A09F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E8601563-E736-42E8-BB7B-A56120E153BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8601563-E736-42E8-BB7B-A56120E153BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8601563-E736-42E8-BB7B-A56120E153BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8601563-E736-42E8-BB7B-A56120E153BE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6EE95575-4838-4769-8113-97ABD3686417}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6EE95575-4838-4769-8113-97ABD3686417}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6EE95575-4838-4769-8113-97ABD3686417}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6EE95575-4838-4769-8113-97ABD3686417}.Release|Any CPU.Build.0 = Release|Any CPU
+		{59D6182A-6801-42F8-BFB2-FDA9B3C2CC9F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{59D6182A-6801-42F8-BFB2-FDA9B3C2CC9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{59D6182A-6801-42F8-BFB2-FDA9B3C2CC9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{59D6182A-6801-42F8-BFB2-FDA9B3C2CC9F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/NuProj.Tests/Scenarios/References_TargetFramework/TargetFramework45/TargetFramework45.nuproj
+++ b/src/NuProj.Tests/Scenarios/References_TargetFramework/TargetFramework45/TargetFramework45.nuproj
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|AnyCPU">
+      <Configuration>Debug</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|AnyCPU">
+      <Configuration>Release</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>59d6182a-6801-42f8-bfb2-fda9b3c2cc9f</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup>
+    <NuProjPath Condition=" '$(NuProjPath)' == '' ">$(MSBuildExtensionsPath)\NuProj\</NuProjPath>
+  </PropertyGroup>
+  <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
+  <PropertyGroup Label="Configuration">
+    <Id>TargetFramework45</Id>
+    <Version>1.0.0</Version>
+    <Title>TargetFramework45</Title>
+    <Authors>kovalikp</Authors>
+    <Owners>kovalikp</Owners>
+    <Summary>TargetFramework45</Summary>
+    <Description>TargetFramework45</Description>
+    <ReleaseNotes>
+    </ReleaseNotes>
+    <ProjectUrl>
+    </ProjectUrl>
+    <LicenseUrl>
+    </LicenseUrl>
+    <Copyright>Copyright © kovalikp</Copyright>
+    <Tags>TargetFramework45</Tags>
+    <GenerateSymbolPackage>true</GenerateSymbolPackage>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Library\Library.csproj">
+      <TargetFramework>net45</TargetFramework>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(NuProjPath)\NuProj.targets" />
+</Project>

--- a/src/NuProj.Tests/Scenarios/References_TargetFramework/TargetFrameworkAny/TargetFrameworkAny.nuproj
+++ b/src/NuProj.Tests/Scenarios/References_TargetFramework/TargetFrameworkAny/TargetFrameworkAny.nuproj
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|AnyCPU">
+      <Configuration>Debug</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|AnyCPU">
+      <Configuration>Release</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>6ee95575-4838-4769-8113-97abd3686417</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup>
+    <NuProjPath Condition=" '$(NuProjPath)' == '' ">$(MSBuildExtensionsPath)\NuProj\</NuProjPath>
+  </PropertyGroup>
+  <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
+  <PropertyGroup Label="Configuration">
+    <Id>TargetFrameworkAny</Id>
+    <Version>1.0.0</Version>
+    <Title>TargetFrameworkAny</Title>
+    <Authors>kovalikp</Authors>
+    <Owners>kovalikp</Owners>
+    <Summary>TargetFrameworkAny</Summary>
+    <Description>TargetFrameworkAny</Description>
+    <ReleaseNotes>
+    </ReleaseNotes>
+    <ProjectUrl>
+    </ProjectUrl>
+    <LicenseUrl>
+    </LicenseUrl>
+    <Copyright>Copyright © kovalikp</Copyright>
+    <Tags>TargetFrameworkAny</Tags>
+    <GenerateSymbolPackage>true</GenerateSymbolPackage>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Library\Library.csproj">
+      <TargetFramework></TargetFramework>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(NuProjPath)\NuProj.targets" />
+</Project>

--- a/src/NuProj.Tests/Scenarios/References_TargetFramework/TargetFrameworkMoniker/TargetFrameworkMoniker.nuproj
+++ b/src/NuProj.Tests/Scenarios/References_TargetFramework/TargetFrameworkMoniker/TargetFrameworkMoniker.nuproj
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|AnyCPU">
+      <Configuration>Debug</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|AnyCPU">
+      <Configuration>Release</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>e8601563-e736-42e8-bb7b-a56120e153be</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup>
+    <NuProjPath Condition=" '$(NuProjPath)' == '' ">$(MSBuildExtensionsPath)\NuProj\</NuProjPath>
+  </PropertyGroup>
+  <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
+  <PropertyGroup Label="Configuration">
+    <Id>TargetFrameworkMoniker</Id>
+    <Version>1.0.0</Version>
+    <Title>TargetFrameworkMoniker</Title>
+    <Authors>kovalikp</Authors>
+    <Owners>kovalikp</Owners>
+    <Summary>TargetFrameworkMoniker</Summary>
+    <Description>TargetFrameworkMoniker</Description>
+    <ReleaseNotes>
+    </ReleaseNotes>
+    <ProjectUrl>
+    </ProjectUrl>
+    <LicenseUrl>
+    </LicenseUrl>
+    <Copyright>Copyright © kovalikp</Copyright>
+    <Tags>TargetFrameworkMoniker</Tags>
+    <GenerateSymbolPackage>true</GenerateSymbolPackage>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Library\Library.csproj">
+      <TargetFramework>TargetFrameworkMoniker</TargetFramework>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(NuProjPath)\NuProj.targets" />
+</Project>


### PR DESCRIPTION
Added option to set `TargetFramework` metadata for project references. Default value is `TargetFrameworkMoniker`, which will use `GetTargetFrameworkMoniker` target to resolve it. Empty string is valid value for "Use any" framework.

Refences with `PackageDirectory` set to `Tools` or `Build` will use target framework subdirectory, unless instructed otherwise.