### PR TITLE
Xunit to display only test method names

### DIFF
--- a/src/NuProj.Tests/NuProj.Tests.csproj
+++ b/src/NuProj.Tests/NuProj.Tests.csproj
@@ -109,6 +109,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/src/NuProj.Tests/app.config
+++ b/src/NuProj.Tests/app.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <appSettings>
+    <add key="xunit.methodDisplay" value="method" />
+  </appSettings>
+</configuration>


### PR DESCRIPTION
Before this, Xunit2 would show fully-qualified test methods (with namespace and class) in its list, which is redundant with the test class name which has been embedded in each test method's own name.

Eventually the "right" fix is probably to simplify all our test method names and then revert this change. But that will be considerably more work, and in the meantime this commit will make the UI more accessible."