### PR TITLE
Update version from 0.9.3 to 0.10.0

### DIFF
--- a/src/Common/CommonAssemblyInfo.cs
+++ b/src/Common/CommonAssemblyInfo.cs
@@ -12,5 +12,5 @@
 // NOTE: When updating the version, you also need to update the Identity/@Version
 //       attribtute in src\NuProj.Package\source.extension.vsixmanifest.
 
-[assembly: AssemblyVersion("0.9.3.0")]
-[assembly: AssemblyFileVersion("0.9.3.0")]
+[assembly: AssemblyVersion("0.10.0.0")]
+[assembly: AssemblyFileVersion("0.10.0.0")]

--- a/src/NuProj.Package/source.extension.vsixmanifest
+++ b/src/NuProj.Package/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="267c66da-0c67-4933-9ae7-a20c53608e49" Version="0.9.3" Language="en-US" Publisher="NuGet" />
+    <Identity Id="267c66da-0c67-4933-9ae7-a20c53608e49" Version="0.10.0.0" Language="en-US" Publisher="NuGet" />
     <DisplayName>NuGet Package Project</DisplayName>
     <Description xml:space="preserve">Provides a NuGet package project (*.nuproj).</Description>
     <MoreInfo>http://bit.ly/NuProjVS</MoreInfo>


### PR DESCRIPTION
The increment of the minor version rather than the patch version is based on the fact that significant and backward breaking changes have been made. Yes, the nuget package is "unstable" right now (which is why we're not obliged to increment the major component), but we should try to communicate to consumers that something more than a simple patch update has been applied. And the minor component seems like the best place to do that.