### PR TITLE
Fix badges to match new org structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 [build-status-img]: http://img.shields.io/appveyor/ci/terrajobst/nuproj.svg?style=flat
 [build-status-url]: https://ci.appveyor.com/project/terrajobst/nuproj
 
-[pull-requests-img]: http://www.issuestats.com/github/terrajobst/nuproj/badge/pr
-[pull-requests-url]: http://www.issuestats.com/github/terrajobst/nuproj
+[pull-requests-img]: http://www.issuestats.com/github/nuproj/nuproj/badge/pr
+[pull-requests-url]: http://www.issuestats.com/github/nuproj/nuproj
 
-[issues-closed-img]: http://www.issuestats.com/github/terrajobst/nuproj/badge/issue
-[issues-closed-url]: http://www.issuestats.com/github/terrajobst/nuproj
+[issues-closed-img]: http://www.issuestats.com/github/nuproj/nuproj/badge/issue
+[issues-closed-url]: http://www.issuestats.com/github/nuproj/nuproj
 
 NuProj provides MSBuild based support for creating NuGet packages (.nupkg).
 


### PR DESCRIPTION
I didn't update the references to the badges after the org changes which caused them to be stale. This fixes that.

Please note the AppVeyor URL didn't change because those aren't associated with the org but with the user owning the build.