### PR TITLE
Add PrepareForBuild target

### DIFF
--- a/src/NuProj.Targets/NuProj.targets
+++ b/src/NuProj.Targets/NuProj.targets
@@ -174,6 +174,20 @@
   <UsingTask AssemblyFile="$(NuProjTasksPath)" TaskName="AssignSourceTargetPaths" />
 
   <!--
+    ============================================================
+                                        PrepareForBuild
+
+    Prepare the prerequisites for building.
+    ============================================================
+    -->
+    <PropertyGroup>
+      <PrepareForBuildDependsOn>EstablishNuGetPaths</PrepareForBuildDependsOn>
+    </PropertyGroup>
+    <Target Name="PrepareForBuild"
+            DependsOnTargets="$(PrepareForBuildDependsOn)">
+    </Target>
+
+    <!--
     ===================================================================================================================
     _NuProjGetProjectClosure
     ===================================================================================================================
@@ -538,7 +552,7 @@
                   $(NuSpecPath);
                   @(File)"
           Outputs="$(NuGetOutputPath)"
-          DependsOnTargets="GenerateNuSpec;EstablishNuGetPaths">
+          DependsOnTargets="GenerateNuSpec;PrepareForBuild">
     <MakeDir Directories="$(OutDir)"
              Condition="!Exists('$(OutDir)')" />
     <NuGetPack OutputDirectory="$(OutDir)"


### PR DESCRIPTION
This is a popular target from Microsoft.Common.targets but NuProj didn't import or define it. This caused issues when a NuGet package with a .props or .targets import is installed into a NuProj itself, and the NuGet package manager adds a target to the NuProj that runs with PrepareForBuild, but since we didn't define the target, NuGet's own target never ran.

Fixes #116 