### PR TITLE
Avoid double-build of referenced projects

### DIFF
--- a/src/NuProj.Targets/NuProj.targets
+++ b/src/NuProj.Targets/NuProj.targets
@@ -169,12 +169,6 @@
       Configuration=$(Configuration);
       Platform=$(Platform)
     </ProjectProperties>
-
-    <!-- Use 'Microsoft.Common.NuProj.targets' if it's in same directory as this script. 
-         For example when using NuProj NuGet package instead of VS integration.-->
-    <ProjectProperties Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.Common.NuProj.targets') And !$(CustomAfterMicrosoftCommonTargets.Contains('Microsoft.Common.NuProj.targets'))">
-      $(ProjectProperties);CustomAfterMicrosoftCommonTargets=$(MSBuildThisFileDirectory)Microsoft.Common.NuProj.targets
-    </ProjectProperties>
   </PropertyGroup>
 
   <!--
@@ -234,7 +228,7 @@
           Inputs="%(ProjectReference.Identity)"
           Outputs="fake"
           Returns="@(_ProjectReferenceClosure)">
-    <!-- First let's make sure that the project references have been fully build,
+    <!-- First let's make sure that the project references have been fully built,
              unless building project references is disabled. -->
 
     <MSBuild Targets="Build"

--- a/src/NuProj.Tasks/NuProj.Tasks.csproj
+++ b/src/NuProj.Tasks/NuProj.Tasks.csproj
@@ -124,11 +124,5 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  <Import Project="..\NuProj.Targets\Microsoft.Common.NuProj.targets" />
 </Project>

--- a/src/NuProj.Tests/Infrastructure/MSBuild.cs
+++ b/src/NuProj.Tests/Infrastructure/MSBuild.cs
@@ -128,11 +128,17 @@ namespace NuProj.Tests.Infrastructure
             /// <summary>
             /// Gets the global properties to pass to indicate where NuProj imports can be found.
             /// </summary>
+            /// <remarks>
+            /// For purposes of true verifications, this map of global properties should
+            /// NOT include any that are propagated by project references from NuProj
+            /// or else their presence here (which does not reflect what the user's solution
+            /// typically builds with) may mask over-build errors that would otherwise
+            /// be caught by our BuildResultAndLogs.AssertNoTargetsExecutedTwice method.
+            /// </remarks>
             public static readonly ImmutableDictionary<string, string> Default = Empty
                 .Add("NuProjPath", Assets.NuProjPath)
                 .Add("NuProjTasksPath", Assets.NuProjTasksPath)
-                .Add("NuGetToolPath", Assets.NuGetToolPath)
-                .Add("CustomAfterMicrosoftCommonTargets", Assets.MicrosoftCommonNuProjTargetsPath);
+                .Add("NuGetToolPath", Assets.NuGetToolPath);
 
             /// <summary>
             /// The project will build in the same manner as if it were building inside Visual Studio.

--- a/src/NuProj.Tests/Infrastructure/MSBuild.cs
+++ b/src/NuProj.Tests/Infrastructure/MSBuild.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 
 using Microsoft.Build.Execution;
@@ -16,7 +17,6 @@ namespace NuProj.Tests.Infrastructure
     {
         public static Task<BuildResultAndLogs> RebuildAsync(string projectPath, string projectName = null, IDictionary<string, string> properties = null)
         {
-
             var target = string.IsNullOrEmpty(projectName) ? "Rebuild" : projectName.Replace('.', '_') + ":Rebuild";
             return MSBuild.ExecuteAsync(projectPath, new[] { target }, properties);
         }
@@ -174,6 +174,7 @@ namespace NuProj.Tests.Infrastructure
             public void AssertSuccessfulBuild()
             {
                 Assert.False(ErrorEvents.Any(), ErrorEvents.Select(e => e.Message).FirstOrDefault());
+                this.AssertNoTargetsExecutedTwice();
                 Assert.Equal(BuildResultCode.Success, Result.OverallResult);
             }
 
@@ -181,6 +182,73 @@ namespace NuProj.Tests.Infrastructure
             {
                 Assert.Equal(BuildResultCode.Failure, Result.OverallResult);
                 Assert.True(ErrorEvents.Any(), ErrorEvents.Select(e => e.Message).FirstOrDefault());
+            }
+
+            /// <summary>
+            /// Verifies that we don't have multi-proc build bugs that may cause
+            /// build failures as a result of projects building multiple times.
+            /// </summary>
+            private void AssertNoTargetsExecutedTwice()
+            {
+                var projectPathToId = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+                var configurations = new Dictionary<long, ProjectStartedEventArgs>();
+                foreach (var projectStarted in this.LogEvents.OfType<ProjectStartedEventArgs>())
+                {
+                    if (!configurations.ContainsKey(projectStarted.BuildEventContext.ProjectInstanceId))
+                    {
+                        configurations.Add(projectStarted.BuildEventContext.ProjectInstanceId, projectStarted);
+                    }
+
+                    long existingId;
+                    if (projectPathToId.TryGetValue(projectStarted.ProjectFile, out existingId))
+                    {
+                        if (existingId != projectStarted.BuildEventContext.ProjectInstanceId)
+                        {
+                            var originalProjectStarted = configurations[existingId];
+                            var originalRequestingProject = configurations[originalProjectStarted.ParentProjectBuildEventContext.ProjectInstanceId].ProjectFile;
+
+                            var requestingProject = configurations[projectStarted.ParentProjectBuildEventContext.ProjectInstanceId].ProjectFile;
+
+                            var globalPropertiesFirst = originalProjectStarted.GlobalProperties.Select(kv => $"{kv.Key}={kv.Value}").ToImmutableHashSet();
+                            var globalPropertiesSecond = projectStarted.GlobalProperties.Select(kv => $"{kv.Key}={kv.Value}").ToImmutableHashSet();
+                            var inFirstNotSecond = globalPropertiesFirst.Except(globalPropertiesSecond);
+                            var inSecondNotFirst = globalPropertiesSecond.Except(globalPropertiesFirst);
+
+                            var messageBuilder = new StringBuilder();
+                            messageBuilder.AppendLine($@"Project ""{projectStarted.ProjectFile}"" was built twice. ");
+                            messageBuilder.Append($@"The first build request came from ""{originalRequestingProject}""");
+                            if (inFirstNotSecond.IsEmpty)
+                            {
+                                messageBuilder.AppendLine();
+                            }
+                            else
+                            {
+                                messageBuilder.AppendLine($" and defined these unique global properties: {string.Join(",", inFirstNotSecond)}");
+                            }
+
+                            messageBuilder.Append($@"The subsequent build request came from ""{requestingProject}""");
+                            if (inSecondNotFirst.IsEmpty)
+                            {
+                                messageBuilder.AppendLine();
+                            }
+                            else
+                            {
+                                messageBuilder.AppendLine($" and defined these unique global properties: {string.Join(",", inSecondNotFirst)}");
+                            }
+
+                            Assert.False(true, messageBuilder.ToString());
+                        }
+                    }
+                    else
+                    {
+                        projectPathToId.Add(projectStarted.ProjectFile, projectStarted.BuildEventContext.ProjectInstanceId);
+                    }
+                }
+            }
+
+            private static string SerializeProperties(IDictionary<string, string> properties)
+            {
+                return string.Join(",", properties.Select(kv => $"{kv.Key}={kv.Value}"));
             }
         }
 
@@ -201,7 +269,7 @@ namespace NuProj.Tests.Infrastructure
             public List<BuildEventArgs> LogEvents { get; set; }
 
             public void Initialize(IEventSource eventSource)
-            {               
+            {
                 _eventSource = eventSource;
                 _eventSource.AnyEventRaised += EventSourceAnyEventRaised;
             }


### PR DESCRIPTION
I added a verifier that runs with every test to cause a test failure if double-build ever occurs. 

Then I removed the test code that sets the `CustomAfterMicrosoftCommonTargets` global property for every build request because that masks the bug in the nuproj.targets file. Users don't set that global property, and the fact that the test does made it appear everywhere, resulting in only a single build in each project even though for the user, double builds result.

Finally, with the bug exposed and tests now failing, I removed the code in NuProj.targets that caused the double-build. I did not see any regressions in the tests from its removal (which was disappointing as this probably _does_ regress something), but I suspect that whatever regressed is less important than fixing frequent timing build failures. And when we identify the regression, we can design a proper fix that doesn't regress this one now that we have a test to help lock it in.

Fix #118