### PR TITLE
Set DevelopmentDependency to True  for NuProj.Common

### DIFF
--- a/src/NuProj.Packages/NuProj.Common.nuproj
+++ b/src/NuProj.Packages/NuProj.Common.nuproj
@@ -29,6 +29,7 @@ There is also a Visual Studio extension which you find under http://bit.ly/NuPro
     <Tags>NuGet nupkg MSBuild NuProj</Tags>
     <NoPackageAnalysis>True</NoPackageAnalysis>
     <GenerateSymbolPackage>False</GenerateSymbolPackage>
+    <DevelopmentDependency>True</DevelopmentDependency>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Prevents consuming .csproj project to list NuProj.Common as dependency.