### PR TITLE
Use solution configuration when building references

### DIFF
--- a/src/NuProj.Targets/NuProj.targets
+++ b/src/NuProj.Targets/NuProj.targets
@@ -161,19 +161,6 @@
   </PropertyGroup>
 
   <!--
-      PROJECT PROPERTIES
-
-      These are the properties we forward to our project references.
-  -->
-
-  <PropertyGroup>
-    <ProjectProperties>
-      Configuration=$(Configuration);
-      Platform=$(Platform)
-    </ProjectProperties>
-  </PropertyGroup>
-
-  <!--
       ITEM DEFINITIONS
       
       Defines default metadata for our items.
@@ -185,6 +172,14 @@
       <TargetFramework></TargetFramework>
     </ProjectReference>
   </ItemDefinitionGroup>
+
+  
+  <!--
+      COMMON TASKS
+  -->
+  
+  <UsingTask TaskName="Microsoft.Build.Tasks.AssignProjectConfiguration"            AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' == ''" />
+  <UsingTask TaskName="Microsoft.Build.Tasks.AssignProjectConfiguration"            AssemblyName="Microsoft.Build.Tasks.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
 
   <!--
       CUSTOM TASKS
@@ -211,7 +206,69 @@
             DependsOnTargets="$(PrepareForBuildDependsOn)">
     </Target>
 
-    <!--
+  <!--
+    ============================================================
+                                        AssignProjectConfiguration
+
+    Assigns the appropriate configuration to each project in the list of project references passed in.
+    Adds to the project references passed in any project references implied by dependencies expressed in the solution file, if any.
+
+        [IN]
+        @(ProjectReference) - the list of all project references
+
+        [OUT]
+        @(ProjectReferenceWithConfiguration) - the list of project references (MSBuild and potentially VSIP projects)
+                                               with metadata values FullConfiguration, Configuration, Platform,
+                                               SetConfiguration, and SetPlatform
+    ============================================================
+    -->
+  <Target
+      Name="AssignProjectConfiguration"
+      Condition="'$(CurrentSolutionConfigurationContents)' != '' or '@(ProjectReference)' != ''">
+
+    <PropertyGroup>
+      <OnlyReferenceAndBuildProjectsEnabledInSolutionConfiguration Condition="'$(OnlyReferenceAndBuildProjectsEnabledInSolutionConfiguration)' == ''">true</OnlyReferenceAndBuildProjectsEnabledInSolutionConfiguration>
+      <ShouldUnsetParentConfigurationAndPlatform Condition="'$(ShouldUnsetParentConfigurationAndPlatform)' == '' and ('$(BuildingInsideVisualStudio)' == 'true' or '$(BuildingSolutionFile)' == 'true')">true</ShouldUnsetParentConfigurationAndPlatform>
+      <ShouldUnsetParentConfigurationAndPlatform Condition="'$(ShouldUnsetParentConfigurationAndPlatform)' == ''">false</ShouldUnsetParentConfigurationAndPlatform>
+
+      <!-- Web Application projects can "secretly" reference Silverlight projects, which can take project dependencies on that same Web Application.  If the project 
+           dependencies are promoted to project references, this ends up creating a situation where we have a circular reference between the two projects.  We don't 
+           want this to happen, so just turn off synthetic project reference generation for Silverlight projects. -->
+      <AddSyntheticProjectReferencesForSolutionDependencies Condition="'$(AddSyntheticProjectReferencesForSolutionDependencies)' == '' and '$(TargetFrameworkIdentifier)' == 'Silverlight'">false</AddSyntheticProjectReferencesForSolutionDependencies>
+
+      <!-- Inside VS, we do not need to add synthetic references, as VS already organizes the build per any solution-level dependencies; we only do this on the command line-->
+      <AddSyntheticProjectReferencesForSolutionDependencies Condition="'$(AddSyntheticProjectReferencesForSolutionDependencies)' == '' and '$(BuildingInsideVisualStudio)' != 'true'">true</AddSyntheticProjectReferencesForSolutionDependencies>
+    </PropertyGroup>
+
+    <!-- Assign a project configuration to each project reference if we're building a solution file. -->
+    <AssignProjectConfiguration
+        ProjectReferences="@(ProjectReference)"
+        CurrentProject="$(MSBuildProjectFullPath)"
+        CurrentProjectConfiguration="$(Configuration)"
+        CurrentProjectPlatform="$(Platform)"
+        DefaultToVcxPlatformMapping="$(DefaultToVcxPlatformMapping)"
+        VcxToDefaultPlatformMapping="$(VcxToDefaultPlatformMapping)"
+        OutputType="$(OutputType)"
+        ResolveConfigurationPlatformUsingMappings="false"
+        SolutionConfigurationContents="$(CurrentSolutionConfigurationContents)"
+        AddSyntheticProjectReferencesForSolutionDependencies="$(AddSyntheticProjectReferencesForSolutionDependencies)"
+        OnlyReferenceAndBuildProjectsEnabledInSolutionConfiguration = "$(OnlyReferenceAndBuildProjectsEnabledInSolutionConfiguration)"
+        ShouldUnsetParentConfigurationAndPlatform = "$(ShouldUnsetParentConfigurationAndPlatform)" >
+
+      <Output TaskParameter="AssignedProjects" ItemName="ProjectReferenceWithConfiguration"/>
+      <Output TaskParameter="UnassignedProjects" ItemName="ProjectReferenceWithConfiguration"/>
+    </AssignProjectConfiguration>
+
+    <ItemGroup>
+      <ProjectReferenceWithConfiguration>
+        <BuildReference Condition="'%(ProjectReferenceWithConfiguration.BuildReference)' == ''">true</BuildReference>
+        <ReferenceOutputAssembly Condition="'%(ProjectReferenceWithConfiguration.ReferenceOutputAssembly)' == ''">true</ReferenceOutputAssembly>
+      </ProjectReferenceWithConfiguration>
+    </ItemGroup>
+  </Target>
+
+
+  <!--
     ===================================================================================================================
     _NuProjGetProjectClosure
     ===================================================================================================================
@@ -219,7 +276,7 @@
     This target returns the closure of all project references.
 
     INPUTS:
-        @(_MSBuildProjectReferenceExistent)   The project references that actually exist.
+        @(ProjectReferenceWithConfiguration)  The project references that actually exist.
 
     OUTPUTS:
         @(_ProjectReferenceClosure)           The closure of all references. Doesn't include duplicates.
@@ -227,7 +284,8 @@
     =================================================================================================================== -->
 
   <Target Name="_NuProjGetProjectClosure"
-          Inputs="%(ProjectReference.Identity)"
+          DependsOnTargets="AssignProjectConfiguration"
+          Inputs="%(ProjectReferenceWithConfiguration.Identity)"
           Outputs="fake"
           Returns="@(_ProjectReferenceClosure)">
     <!-- First let's make sure that the project references have been fully built,
@@ -235,14 +293,14 @@
 
     <MSBuild Targets="Build"
              Condition="'$(BuildProjectReferences)' == 'true'"
-             Projects="@(ProjectReference)"
-             Properties="$(ProjectProperties)"
+             Projects="@(ProjectReferenceWithConfiguration)"
+             Properties="%(ProjectReferenceWithConfiguration.SetConfiguration); %(ProjectReferenceWithConfiguration.SetPlatform)"
              ContinueOnError="WarnAndContinue"/>
 
     <!-- Get closure of indirect references -->
-    <MSBuild Projects="@(ProjectReference)"
+    <MSBuild Projects="@(ProjectReferenceWithConfiguration)"
              Targets="_NuProjGetProjectClosure"
-             Properties="$(ProjectProperties)"
+             Properties="%(ProjectReferenceWithConfiguration.SetConfiguration); %(ProjectReferenceWithConfiguration.SetPlatform)"
              ContinueOnError="WarnAndContinue">
       <Output TaskParameter="TargetOutputs"
               ItemName="_ProjectReferenceClosureWithDuplicates" />
@@ -256,14 +314,14 @@
 
     <ItemGroup>
       <!-- Remove references that are also direct references -->
-      <_ProjectReferenceClosureWithoutMetadata Remove="%(ProjectReference.FullPath)" />
+      <_ProjectReferenceClosureWithoutMetadata Remove="%(ProjectReferenceWithConfiguration.FullPath)" />
       <!-- We can now mark all the closure references as indirect -->
       <_ProjectReferenceClosure Include="@(_ProjectReferenceClosureWithoutMetadata)">
         <DependencyKind>Indirect</DependencyKind>
-        <PackageDirectory>%(ProjectReference.PackageDirectory)</PackageDirectory>
+        <PackageDirectory>%(ProjectReferenceWithConfiguration.PackageDirectory)</PackageDirectory>
       </_ProjectReferenceClosure>
       <!-- Now add the direct references, preserving metadata -->
-      <_ProjectReferenceClosure Include="@(ProjectReference->'%(FullPath)')">
+      <_ProjectReferenceClosure Include="@(ProjectReferenceWithConfiguration->'%(FullPath)')">
         <DependencyKind>Direct</DependencyKind>
       </_ProjectReferenceClosure>
     </ItemGroup>
@@ -278,8 +336,7 @@
     This target will split the project references into NuProj project references and non-NuProj references.
 
     INPUTS:
-        @(ProjectReference)            The direct project references
-        @(_ProjectReferenceClosure)    The direct and indirect project references
+        @(_ProjectReferenceClosure)           The direct and indirect project references
 
     OUTPUTS:
         @(_NuProjProjectReference)            Direct references to NuProj projects.
@@ -338,10 +395,10 @@
     This target will get the build outputs of the project references
 
     INPUTS:
-        @(ProjectReference)         The project references
+        @(_NonNuProjProjectReference)  The project references
 
     OUTPUTS:
-        @(ProjectReferenceOutput)   The output of all project references
+        @(ProjectReferenceOutput)      The output of all project references
 
     =================================================================================================================== -->
 
@@ -354,7 +411,7 @@
 
         <MSBuild Targets="$(ProjectOutputGroups)"
                  Projects="@(_NonNuProjProjectReference)"
-                 Properties="$(ProjectProperties)">
+                 Properties="%(_NonNuProjProjectReference.SetConfiguration); %(_NonNuProjProjectReference.SetPlatform)">
             <Output TaskParameter="TargetOutputs"
                     ItemName="_NonNuProjProjectOutput" />
         </MSBuild>
@@ -376,7 +433,7 @@
 
         <MSBuild Targets="GetTargetPath"
                  Projects="@(_NonNuProjProjectReference)"
-                 Properties="$(ProjectProperties)">
+                 Properties="%(_NonNuProjProjectReference.SetConfiguration); %(_NonNuProjProjectReference.SetPlatform)">
             <Output TaskParameter="TargetOutputs"
                     PropertyName="_NonNuProjProjectTargetPath" />
         </MSBuild>
@@ -400,7 +457,7 @@
 
         <MSBuild Targets="GetTargetFrameworkMoniker"
                  Projects="@(_NonNuProjProjectReference)"
-                 Properties="$(ProjectProperties)">
+                 Properties="%(_NonNuProjProjectReference.SetConfiguration); %(_NonNuProjProjectReference.SetPlatform)">
           
             <Output TaskParameter="TargetOutputs"
                     PropertyName="_NonNuProjProjectTargetFrameworkMoniker" />
@@ -726,7 +783,7 @@
           DependsOnTargets="SplitProjectReferences">
       <MSBuild Targets="GetPackageFiles"
                Projects="@(_NuProjProjectReferenceClosure)"
-               Properties="$(ProjectProperties)">
+               Properties="%(_NuProjProjectReferenceClosure.SetConfiguration); %(_NuProjProjectReferenceClosure.SetPlatform)">
         <Output TaskParameter="TargetOutputs"
                 ItemName="NuProjFileDependency" />
       </MSBuild>
@@ -838,7 +895,7 @@
           DependsOnTargets="SplitProjectReferences">
       <MSBuild Targets="GetPackageIdentity"
                Projects="@(_NuProjProjectReferenceClosure)"
-               Properties="$(ProjectProperties)">
+               Properties="%(_NuProjProjectReferenceClosure.SetConfiguration); %(_NuProjProjectReferenceClosure.SetPlatform)">
         <Output TaskParameter="TargetOutputs"
                 ItemName="_NuProjDependency" />
       </MSBuild>
@@ -945,7 +1002,7 @@
 
     =================================================================================================================== -->
 
-  <Target Name="Clean" DependsOnTargets="EstablishNuGetPaths">
+  <Target Name="Clean" DependsOnTargets="AssignProjectConfiguration;EstablishNuGetPaths">
 
     <!-- We should also clear our references.
 
@@ -954,8 +1011,8 @@
 
     <MSBuild Targets="Clean"
              Condition="'$(BuildProjectReferences)' == 'true'"
-             Projects="@(ProjectReference)"
-             Properties="$(ProjectProperties)" />
+             Projects="@(ProjectReferenceWithConfiguration)"
+             Properties="%(ProjectReferenceWithConfiguration.SetConfiguration); %(ProjectReferenceWithConfiguration.SetPlatform)" />
 
     <!-- Delete our outputs and intermediates. -->
 

--- a/src/NuProj.Tests/Infrastructure/Assets.cs
+++ b/src/NuProj.Tests/Infrastructure/Assets.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Xml;
 
 using Microsoft.Build.Construction;
@@ -45,12 +46,12 @@ namespace NuProj.Tests.Infrastructure
             get { return Path.Combine(ProjectDirectory, "src", "NuProj.Tests", "Scenarios"); }
         }
 
-        public static string GetScenarioDirectory(string scenarioName)
+        public static string GetScenarioDirectory([CallerMemberName] string scenarioName = null)
         {
             return Path.Combine(ScenariosDirectory, scenarioName);
         }
 
-        public static string GetScenarioSolutionPath(string scenarioName)
+        public static string GetScenarioSolutionPath([CallerMemberName] string scenarioName = null)
         {
             var solutioDirectory = GetScenarioDirectory(scenarioName);
             return Path.Combine(solutioDirectory, scenarioName + ".sln");

--- a/src/NuProj.Tests/ReferenceTests.cs
+++ b/src/NuProj.Tests/ReferenceTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using NuGet;
 using NuProj.Tests.Infrastructure;
 using Xunit;
 
@@ -11,6 +12,32 @@ namespace NuProj.Tests
 {
     public class ReferenceTests
     {
+        [Fact]
+        public async Task References_AssignProjectConfiguration()
+        {
+            var package = await Scenario.RestoreAndBuildSinglePackageAsync();
+            var scenarioDirectory = Assets.GetScenarioDirectory();
+            var nuspecFile = Path.Combine(scenarioDirectory, @"Package\obj\Mixed\Package.nuspec");
+            using (var stream = File.OpenRead(nuspecFile))
+            {
+                var manifest = Manifest.ReadFrom(stream, false);
+                var files = manifest.Files
+                    .Select(x => x.Source)
+                    .Select(x => x.Remove(0, scenarioDirectory.Length + 1))
+                    .OrderBy(x => x);
+
+                var expectedFileNames = new[]
+                {
+                    @"Debug_x64\bin\x64\Debug\Debug_x64.dll",
+                    @"Debug_x64\bin\x64\Debug\Debug_x64.pdb",
+                    @"Release_x86\bin\x86\Release\Release_x86.dll",
+                    @"Release_x86\bin\x86\Release\Release_x86.pdb",
+                };
+
+                Assert.Equal(expectedFileNames, files);
+            }
+        }
+
         [Fact]
         public async Task References_PackagedWithCopyLocal()
         {

--- a/src/NuProj.Tests/Scenarios/References_AssignProjectConfiguration/Debug_x64/Class1.cs
+++ b/src/NuProj.Tests/Scenarios/References_AssignProjectConfiguration/Debug_x64/Class1.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Debug_x64
+{
+    public class Class1
+    {
+    }
+}

--- a/src/NuProj.Tests/Scenarios/References_AssignProjectConfiguration/Debug_x64/Debug_x64.csproj
+++ b/src/NuProj.Tests/Scenarios/References_AssignProjectConfiguration/Debug_x64/Debug_x64.csproj
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{AA3E7C1E-311B-4B67-B450-B476105E2234}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Debug_x64</RootNamespace>
+    <AssemblyName>Debug_x64</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Mixed|AnyCPU'">
+    <OutputPath>bin\Mixed\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Mixed|x64'">
+    <OutputPath>bin\x64\Mixed\</OutputPath>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Class1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/NuProj.Tests/Scenarios/References_AssignProjectConfiguration/Debug_x64/Properties/AssemblyInfo.cs
+++ b/src/NuProj.Tests/Scenarios/References_AssignProjectConfiguration/Debug_x64/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Debug_x64")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Debug_x64")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("aa3e7c1e-311b-4b67-b450-b476105e2234")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NuProj.Tests/Scenarios/References_AssignProjectConfiguration/Package/Package.nuproj
+++ b/src/NuProj.Tests/Scenarios/References_AssignProjectConfiguration/Package/Package.nuproj
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|AnyCPU">
+      <Configuration>Debug</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Mixed|AnyCPU">
+      <Configuration>Mixed</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|AnyCPU">
+      <Configuration>Release</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>0b98679c-6418-47fc-a10b-69afdb23b3a4</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup>
+    <NuProjPath Condition=" '$(NuProjPath)' == '' ">$(MSBuildExtensionsPath)\NuProj\</NuProjPath>
+  </PropertyGroup>
+  <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
+  <PropertyGroup Label="Configuration">
+    <Id>Package</Id>
+    <Version>1.0.0</Version>
+    <Title>Package</Title>
+    <Authors>Pavol Kovalik</Authors>
+    <Owners>Pavol Kovalik</Owners>
+    <Summary>Package</Summary>
+    <Description>Package</Description>
+    <ReleaseNotes>
+    </ReleaseNotes>
+    <ProjectUrl>
+    </ProjectUrl>
+    <LicenseUrl>
+    </LicenseUrl>
+    <Copyright>Copyright © Pavol Kovalik</Copyright>
+    <Tags>Package</Tags>
+    <GenerateSymbolPackage>true</GenerateSymbolPackage>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Debug_x64\Debug_x64.csproj" />
+    <ProjectReference Include="..\Release_x86\Release_x86.csproj" />
+  </ItemGroup>
+  <Import Project="$(NuProjPath)\NuProj.targets" />
+</Project>

--- a/src/NuProj.Tests/Scenarios/References_AssignProjectConfiguration/References_AssignProjectConfiguration.sln
+++ b/src/NuProj.Tests/Scenarios/References_AssignProjectConfiguration/References_AssignProjectConfiguration.sln
@@ -1,0 +1,27 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "Package", "Package\Package.nuproj", "{0B98679C-6418-47FC-A10B-69AFDB23B3A4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Debug_x64", "Debug_x64\Debug_x64.csproj", "{AA3E7C1E-311B-4B67-B450-B476105E2234}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Release_x86", "Release_x86\Release_x86.csproj", "{2D609FC5-1458-46D0-9CE4-7EC3A95F7B1E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Mixed|Mixed Platforms = Mixed|Mixed Platforms
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0B98679C-6418-47FC-A10B-69AFDB23B3A4}.Mixed|Mixed Platforms.ActiveCfg = Mixed|Any CPU
+		{0B98679C-6418-47FC-A10B-69AFDB23B3A4}.Mixed|Mixed Platforms.Build.0 = Mixed|Any CPU
+		{AA3E7C1E-311B-4B67-B450-B476105E2234}.Mixed|Mixed Platforms.ActiveCfg = Debug|x64
+		{AA3E7C1E-311B-4B67-B450-B476105E2234}.Mixed|Mixed Platforms.Build.0 = Debug|x64
+		{2D609FC5-1458-46D0-9CE4-7EC3A95F7B1E}.Mixed|Mixed Platforms.ActiveCfg = Release|x86
+		{2D609FC5-1458-46D0-9CE4-7EC3A95F7B1E}.Mixed|Mixed Platforms.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/NuProj.Tests/Scenarios/References_AssignProjectConfiguration/Release_x86/Class1.cs
+++ b/src/NuProj.Tests/Scenarios/References_AssignProjectConfiguration/Release_x86/Class1.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Release_x86
+{
+    public class Class1
+    {
+    }
+}

--- a/src/NuProj.Tests/Scenarios/References_AssignProjectConfiguration/Release_x86/Properties/AssemblyInfo.cs
+++ b/src/NuProj.Tests/Scenarios/References_AssignProjectConfiguration/Release_x86/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Release_x86")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Release_x86")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("2d609fc5-1458-46d0-9ce4-7ec3a95f7b1e")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NuProj.Tests/Scenarios/References_AssignProjectConfiguration/Release_x86/Release_x86.csproj
+++ b/src/NuProj.Tests/Scenarios/References_AssignProjectConfiguration/Release_x86/Release_x86.csproj
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{2D609FC5-1458-46D0-9CE4-7EC3A95F7B1E}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Release_x86</RootNamespace>
+    <AssemblyName>Release_x86</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Mixed|AnyCPU'">
+    <OutputPath>bin\Mixed\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Mixed|x86'">
+    <OutputPath>bin\x86\Mixed\</OutputPath>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Class1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/NuProj.sln
+++ b/src/NuProj.sln
@@ -20,6 +20,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{6C4096
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Targets", "Targets", "{B990C73A-43DF-45E0-B616-5DBA2D2060F3}"
 	ProjectSection(SolutionItems) = preProject
+		NuProj.Targets\Microsoft.Common.NuProj.targets = NuProj.Targets\Microsoft.Common.NuProj.targets
 		NuProj.Targets\NuProj.props = NuProj.Targets\NuProj.props
 		NuProj.Targets\NuProj.targets = NuProj.Targets\NuProj.targets
 	EndProjectSection


### PR DESCRIPTION
Resolves #119. Uses `AssignProjectConfiguration` task to assign project configuration and platform to build references, as defined in solution. 