### PR TITLE
Fix InvalidOperationException thrown when NuGet restore fails

### DIFF
--- a/src/NuProj.Tests/Infrastructure/NuGetHelper.cs
+++ b/src/NuProj.Tests/Infrastructure/NuGetHelper.cs
@@ -66,12 +66,14 @@ namespace NuProj.Tests.Infrastructure
                         var message = String.Format("NuGet package restore failed.{0}{1}", Environment.NewLine, output);
                         tcs.SetException(new Exception(message));
                     }
-
-                    tcs.SetResult(process.ExitCode);
+                    else
+                    {
+                        tcs.SetResult(process.ExitCode);
+                    }
                 }
                 finally
                 {
-                    process.Dispose();                   
+                    process.Dispose();
                 }
             };
 


### PR DESCRIPTION
Right after calling TCS.SetException we inevitably went on to call SetResult which will of course throw. We now ensure that we only call one or the other.

Fix #143 