### PR TITLE
Build using the NuGet package delivered WiX toolset

### DIFF
--- a/src/NuProj.Setup/NuProj.Setup.wixproj
+++ b/src/NuProj.Setup/NuProj.Setup.wixproj
@@ -8,8 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <OutputName>NuProj</OutputName>
     <OutputType>Package</OutputType>
-    <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
-    <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
+    <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">..\packages\WiX.Toolset.3.9.1208.0\tools\wix\Wix.targets</WixTargetsPath>
+    <WixInstallPath>$(MSBuildProjectDirectory)\..\packages\WiX.Toolset.3.9.1208.0\tools\wix</WixInstallPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <OutputPath>bin\$(Configuration)\</OutputPath>

--- a/tools/binaries.proj
+++ b/tools/binaries.proj
@@ -5,9 +5,6 @@
 
   <PropertyGroup>
     <BuildInParallel Condition="'$(BuildInParallel)' == ''">True</BuildInParallel>
-    <WixToolPath>$(SourceDir)\packages\WiX.Toolset.3.9.1208.0\tools\wix\</WixToolPath>
-    <WixTargetsPath>$(WixToolPath)Wix.targets</WixTargetsPath>
-    <WixTasksPath>$(WixToolPath)wixtasks.dll</WixTasksPath>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -16,9 +13,6 @@
       Configuration=$(Configuration);
       Platform=$(Platform);
       OutDir=$(OutDir)raw\;
-      WixToolPath=$(WixToolPath);
-      WixTargetsPath=$(WixTargetsPath);
-      WixTasksPath=$(WixTasksPath);
     </ProjectProperties>
   </PropertyGroup>
 


### PR DESCRIPTION
This removes the requirement for the WiX toolset to be installed in order to build on dev boxes (or in the cloud)

In fact we already have the WiX toolset dependency brought in via NuGet, but the WiX project wasn't using it. This change makes it set up the properties to use it.