### PR TITLE
Import NuProj.Common.targets in all project types

### DIFF
--- a/src/NuProj.Packages/NuProj.Common.nuproj
+++ b/src/NuProj.Packages/NuProj.Common.nuproj
@@ -36,6 +36,12 @@ There is also a Visual Studio extension which you find under http://bit.ly/NuPro
     <Content Include="$(BasePath)raw\Additional\Microsoft.Common.NuProj.targets">
       <Link>build\NuProj.Common.targets</Link>
     </Content>
+    <Content Include="$(BasePath)raw\Additional\Redirect.targets">
+      <Link>build\portable-net+win+wpa+wp+sl+net-cf+netmf+MonoAndroid+MonoTouch+Xamarin.iOS\NuProj.Common.targets</Link>
+    </Content>
+    <Content Include="$(BasePath)raw\Additional\Redirect.targets">
+      <Link>build\dotnet\NuProj.Common.targets</Link>
+    </Content>
   </ItemGroup>
 
   <Import Project="$(NuProjPath)\NuProj.targets" />

--- a/src/NuProj.Targets/Redirect.targets
+++ b/src/NuProj.Targets/Redirect.targets
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\$(MSBuildThisFileName)$(MSBuildThisFileExtension)" />
+</Project>

--- a/src/NuProj.Tasks/NuProj.Tasks.csproj
+++ b/src/NuProj.Tasks/NuProj.Tasks.csproj
@@ -85,6 +85,10 @@
       <Link>Additional\NuProj.props</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="..\NuProj.Targets\Redirect.targets">
+      <Link>Additional\Redirect.targets</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>


### PR DESCRIPTION
The problem with the old mechanism is that the imported .targets file was directly in the NuGet package's build folder, which NuGet interprets as implying "net40". So it doesn't work with other platforms or PCLs. This fix puts a redirecting .targets file in the dotnet and a portable-* folder.

Fix #160 
