### PR TITLE
Add support for placeholder dependency indicating empty dependency group

### DIFF
--- a/src/NuProj.Tasks/GenerateNuSpec.cs
+++ b/src/NuProj.Tasks/GenerateNuSpec.cs
@@ -210,6 +210,7 @@ namespace NuProj.Tasks
                     {
                         TargetFramework = dependenciesByFramework.Key.GetShortFrameworkName(),
                         Dependencies = (from dependency in dependenciesByFramework
+                                        where dependency.Id != "_._"
                                         group dependency by dependency.Id into dependenciesById
                                         select new ManifestDependency
                                         {


### PR DESCRIPTION
Sample usage:
```
<Dependency Include="_._">
  <TargetFramework>net46</TargetFramework>
</Dependency>
```

An empty dependency group is needed when you support a platform but don't need any dependencies but another group (for example an earlier framework) required dependencies.