### PR TITLE
Use MSBuild 12/14

### DIFF
--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NuGet.CommandLine" version="2.8.6" />
   <package id="WiX.Toolset" version="3.9.1208" />
 </packages>

--- a/src/NuProj.Packages/NuProj.nuproj
+++ b/src/NuProj.Packages/NuProj.nuproj
@@ -51,7 +51,7 @@ There is also a Visual Studio extension which you find under http://bit.ly/NuPro
     <Content Include="$(BasePath)raw\Additional\Microsoft.Common.NuProj.targets">
       <Link>tools\Microsoft.Common.NuProj.targets</Link>
     </Content>
-    <Content Include="..\packages\NuGet.CommandLine.2.8.6\tools\NuGet.exe">
+    <Content Include="..\packages\NuGet.CommandLine.3.3.0\tools\NuGet.exe">
       <Link>tools\NuGet.exe</Link>
     </Content>
     <Content Include="$(BasePath)raw\Additional\Rules\content.xaml">

--- a/src/NuProj.Setup/Feature.BuildIntegration.wxs
+++ b/src/NuProj.Setup/Feature.BuildIntegration.wxs
@@ -32,7 +32,7 @@
 
     <ComponentGroup Id="MSBuildIntegration">
       <Component Directory="INSTALLDIR">
-        <File Source="$(var.SolutionDir)packages\NuGet.CommandLine.2.8.6\tools\NuGet.exe" />
+        <File Source="$(var.SolutionDir)packages\NuGet.CommandLine.3.3.0\tools\NuGet.exe" />
       </Component>
       <Component Directory="INSTALLDIR">
         <File Source="$(var.NuProj.Tasks.TargetDir)Additional\NuProj.targets" />

--- a/src/NuProj.Tasks/NuProj.Tasks.csproj
+++ b/src/NuProj.Tasks/NuProj.Tasks.csproj
@@ -41,8 +41,8 @@
     <AssemblyOriginatorKeyFile>..\Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Build.Framework" />
-    <Reference Include="Microsoft.Build.Utilities.v4.0" />
+    <Reference Include="Microsoft.Build.Framework, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.Build.Utilities.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
       <Private>True</Private>

--- a/src/NuProj.Tests/BasicTests.cs
+++ b/src/NuProj.Tests/BasicTests.cs
@@ -10,15 +10,18 @@ using Microsoft.Build.Execution;
 using NuProj.Tests.Infrastructure;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace NuProj.Tests
 {
     public class BasicTests : IDisposable
     {
+        private readonly ITestOutputHelper logger;
         private Microsoft.Build.Evaluation.Project nuproj;
 
-        public BasicTests()
+        public BasicTests(ITestOutputHelper logger)
         {
+            this.logger = logger;
             this.nuproj = Assets.FromTemplate()
                                 .AssignNuProjDirectory()
                                 .ToProject();
@@ -36,7 +39,7 @@ namespace NuProj.Tests
         public async Task Basic_ProjectTemplateCanBuild()
         {
             nuproj.CreateMockContentFiles();
-            var result = await MSBuild.ExecuteAsync(nuproj.CreateProjectInstance());
+            var result = await MSBuild.ExecuteAsync(nuproj.CreateProjectInstance(), this.logger);
             result.AssertSuccessfulBuild();
         }
 
@@ -52,7 +55,7 @@ namespace NuProj.Tests
         public async Task Basic_PackageIncludesContentFiles()
         {
             nuproj.CreateMockContentFiles();
-            var result = await MSBuild.ExecuteAsync(nuproj.CreateProjectInstance());
+            var result = await MSBuild.ExecuteAsync(nuproj.CreateProjectInstance(), this.logger);
             result.AssertSuccessfulBuild();
             await AssertNu.PackageContainsContentItemsAsync(nuproj);
         }
@@ -61,7 +64,7 @@ namespace NuProj.Tests
         public async Task Basic_NuSpecPropertiesMatchProjectProperties()
         {
             nuproj.CreateMockContentFiles();
-            var result = await MSBuild.ExecuteAsync(nuproj.CreateProjectInstance());
+            var result = await MSBuild.ExecuteAsync(nuproj.CreateProjectInstance(), this.logger);
             result.AssertSuccessfulBuild();
 
             var package = await nuproj.GetPackageAsync();
@@ -98,7 +101,7 @@ namespace NuProj.Tests
             // This test focuses on a completely empty project.
             nuproj.RemoveItems(nuproj.GetItems("Content"));
 
-            var result = await MSBuild.ExecuteAsync(nuproj.CreateProjectInstance());
+            var result = await MSBuild.ExecuteAsync(nuproj.CreateProjectInstance(), this.logger);
 
             // Verify that the build fails and tells the user why.
             Assert.Equal(BuildResultCode.Failure, result.Result.OverallResult);
@@ -112,7 +115,7 @@ namespace NuProj.Tests
             nuproj.CreateMockContentFiles();
             nuproj.SetGlobalProperty("IntermediateOutputPath", intermediateOutputPath);
 
-            var result = await MSBuild.ExecuteAsync(nuproj.CreateProjectInstance());
+            var result = await MSBuild.ExecuteAsync(nuproj.CreateProjectInstance(), this.logger);
             result.AssertSuccessfulBuild();
 
             var expectedNuSpecFileName = string.Format(CultureInfo.InvariantCulture, "{0}.nuspec", nuproj.GetPropertyValue("Id"));
@@ -130,7 +133,7 @@ namespace NuProj.Tests
             nuproj.SetGlobalProperty("IntermediateOutputPath", intermediateOutputPath);
             nuproj.SetGlobalProperty("GenerateProjectSpecificOutputFolder", @"true");
 
-            var result = await MSBuild.ExecuteAsync(nuproj.CreateProjectInstance());
+            var result = await MSBuild.ExecuteAsync(nuproj.CreateProjectInstance(), this.logger);
             result.AssertSuccessfulBuild();
 
             var expectedNuSpecFileName = string.Format(CultureInfo.InvariantCulture, "{0}.nuspec", nuproj.GetPropertyValue("Id"));
@@ -147,7 +150,7 @@ namespace NuProj.Tests
             nuproj.CreateMockContentFiles();
             nuproj.SetGlobalProperty("OutDir", outDir);
 
-            var result = await MSBuild.ExecuteAsync(nuproj.CreateProjectInstance());
+            var result = await MSBuild.ExecuteAsync(nuproj.CreateProjectInstance(), this.logger);
             result.AssertSuccessfulBuild();
 
             var expectedNuPkgFileName = string.Format(CultureInfo.InvariantCulture, "{0}.{1}.nupkg", nuproj.GetPropertyValue("Id"), nuproj.GetPropertyValue("Version"));
@@ -166,7 +169,7 @@ namespace NuProj.Tests
             nuproj.SetGlobalProperty("OutDir", outDir);
             nuproj.SetGlobalProperty("GenerateProjectSpecificOutputFolder", @"true");
 
-            var result = await MSBuild.ExecuteAsync(nuproj.CreateProjectInstance());
+            var result = await MSBuild.ExecuteAsync(nuproj.CreateProjectInstance(), this.logger);
             result.AssertSuccessfulBuild();
 
             var expectedNuPkgFileName = string.Format(CultureInfo.InvariantCulture, "{0}.{1}.nupkg", nuproj.GetPropertyValue("Id"), nuproj.GetPropertyValue("Version"));

--- a/src/NuProj.Tests/Infrastructure/Assets.cs
+++ b/src/NuProj.Tests/Infrastructure/Assets.cs
@@ -28,7 +28,7 @@ namespace NuProj.Tests.Infrastructure
 
         public static string NuGetToolPath
         {
-            get { return Path.Combine(ProjectDirectory, @"src\packages\NuGet.CommandLine.2.8.6\tools"); }
+            get { return Path.Combine(ProjectDirectory, @"src\packages\NuGet.CommandLine.3.3.0\tools"); }
         }
 
         public static string NuGetExePath

--- a/src/NuProj.Tests/Infrastructure/MSBuild.cs
+++ b/src/NuProj.Tests/Infrastructure/MSBuild.cs
@@ -75,7 +75,7 @@ namespace NuProj.Tests.Infrastructure
         /// <param name="projectInstance">The project to build.</param>
         /// <param name="targetsToBuild">The targets to build. If not specified, the project's default target will be invoked.</param>
         /// <returns>A task whose result is the result of the build.</returns>
-        public static async Task<BuildResultAndLogs> ExecuteAsync(ProjectInstance projectInstance, params string[] targetsToBuild)
+        public static async Task<BuildResultAndLogs> ExecuteAsync(ProjectInstance projectInstance, ITestOutputHelper testLogger = null, params string[] targetsToBuild)
         {
             targetsToBuild = (targetsToBuild == null || targetsToBuild.Length == 0) ? projectInstance.DefaultTargets.ToArray() : targetsToBuild;
 
@@ -86,6 +86,7 @@ namespace NuProj.Tests.Infrastructure
                 Loggers = new List<ILogger>
                 {
                     new ConsoleLogger(LoggerVerbosity.Detailed, logLines.Add, null, null),
+                    new ConsoleLogger(LoggerVerbosity.Minimal, v => testLogger?.WriteLine(v.TrimEnd()), null, null),
                     logger,
                 },
             };

--- a/src/NuProj.Tests/Infrastructure/ProjectBuilder.cs
+++ b/src/NuProj.Tests/Infrastructure/ProjectBuilder.cs
@@ -50,14 +50,14 @@ namespace NuProj.Tests.Infrastructure
 
         public static async Task<string> GetNuPkgPathAsync(this Project nuProj)
         {
-            var result = await MSBuild.ExecuteAsync(nuProj.CreateProjectInstance(), "EstablishNuGetPaths");
+            var result = await MSBuild.ExecuteAsync(nuProj.CreateProjectInstance(), targetsToBuild: "EstablishNuGetPaths");
             AssertNu.SuccessfulBuild(result);
             return result.Result.ProjectStateAfterBuild.GetPropertyValue("NuGetOutputPath");
         }
 
         public static async Task<string> GetNuSpecPathAsync(this Project nuProj)
         {
-            var result = await MSBuild.ExecuteAsync(nuProj.CreateProjectInstance(), "EstablishNuGetPaths");
+            var result = await MSBuild.ExecuteAsync(nuProj.CreateProjectInstance(), targetsToBuild: "EstablishNuGetPaths");
             AssertNu.SuccessfulBuild(result);
             return result.Result.ProjectStateAfterBuild.GetPropertyValue("NuSpecPath");
         }

--- a/src/NuProj.Tests/NuProj.Tests.csproj
+++ b/src/NuProj.Tests/NuProj.Tests.csproj
@@ -36,9 +36,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Build" />
-    <Reference Include="Microsoft.Build.Framework" />
-    <Reference Include="Microsoft.Build.Utilities.v4.0" />
+    <Reference Include="Microsoft.Build, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.Build.Framework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.Build.Utilities.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.Build.Utilities.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <Aliases>MSBuildUtil12</Aliases>
+    </Reference>
     <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
       <Private>True</Private>

--- a/src/NuProj.Tests/app.config
+++ b/src/NuProj.Tests/app.config
@@ -3,4 +3,16 @@
   <appSettings>
     <add key="xunit.methodDisplay" value="method" />
   </appSettings>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="2.0.0.0-12.0.0.0" newVersion="14.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="2.0.0.0-12.0.0.0" newVersion="14.0.0.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/src/NuProj.Tests/packages.config
+++ b/src/NuProj.Tests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net451" />
   <package id="Nerdbank.GitVersioning" version="1.3.13" targetFramework="net451" developmentDependency="true" />
-  <package id="NuGet.CommandLine" version="2.8.6" />
+  <package id="NuGet.CommandLine" version="3.3.0" />
   <package id="NuGet.Core" version="2.8.6" targetFramework="net451" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net451" />
   <package id="xunit" version="2.0.0" targetFramework="net451" />

--- a/tools/package.proj
+++ b/tools/package.proj
@@ -26,7 +26,7 @@
       NuProjPath=$(OutDir)raw\Additional\;
       NuProjTasksPath=$(OutDir)raw\NuProj.Tasks.dll;
       NuProjToolPath=$(OutDir)raw\;
-      NuGetToolPath=$(SourceDir)packages\NuGet.CommandLine.2.8.6\tools\;
+      NuGetToolPath=$(SourceDir)packages\NuGet.CommandLine.3.3.0\tools\;
     </ProjectProperties>
   </PropertyGroup>
   


### PR DESCRIPTION
Build against MSBuild 12, and test using MSBuild 14 to later enable adding tests for project.json support, which requires MSBuild 14.

Before this, we were using MSBuild 4 in tests, which NuProj itself never supported. By building the product against MSBuild 12, we don't cut support for any previously supported versions. By testing against MSBuild 14, we open up the opportunity to test project.json.