### PR TITLE
Support for MSBuild 14.0+

### DIFF
--- a/src/NuProj.Targets/NuProj.targets
+++ b/src/NuProj.Targets/NuProj.targets
@@ -174,7 +174,8 @@
   -->
   
   <UsingTask TaskName="Microsoft.Build.Tasks.AssignProjectConfiguration"            AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' == ''" />
-  <UsingTask TaskName="Microsoft.Build.Tasks.AssignProjectConfiguration"            AssemblyName="Microsoft.Build.Tasks.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
+  <UsingTask TaskName="Microsoft.Build.Tasks.AssignProjectConfiguration"            AssemblyName="Microsoft.Build.Tasks.v$(MSBuildAssemblyVersion), Version=$(MSBuildAssemblyVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' &lt;= '12.0'" />
+  <UsingTask TaskName="Microsoft.Build.Tasks.AssignProjectConfiguration"            AssemblyName="Microsoft.Build.Tasks.Core, Version=$(MSBuildAssemblyVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' &gt;= '14.0'" />
 
   <!--
       CUSTOM TASKS


### PR DESCRIPTION
Update <UsingTask /> of "AssignProjectConfiguration" for MSBuild 14.0 and above

In MSBuild 14.0, the tasks assembly was renamed to Microsoft.Build.Tasks.Core.dll.  So this condition will work for MSBuild 14.0 and above.

Fixes #257 