### PR TITLE
Update GenerateNuSpec.GetContentFilesIncludePath

### DIFF
--- a/src/NuProj.Tasks/GenerateNuSpec.cs
+++ b/src/NuProj.Tasks/GenerateNuSpec.cs
@@ -275,8 +275,7 @@ namespace NuProj.Tasks
                 Log.LogError($"File '{taskItem.ItemSpec}' has unexpected PackageDirectory metadata. Expected '{PackageDirectory.ContentFiles}', actual '{packageDirectory}'.");
             }
 
-            var source = taskItem.GetMetadata(Metadata.FileSource);
-            return Path.Combine(targetSubdirectory, Path.GetFileName(source));
+            return targetSubdirectory;
         }
 
         private static IVersionSpec AggregateVersions(IVersionSpec aggregate, IVersionSpec next)


### PR DESCRIPTION
Don't duplicate file name in return from GetContentFilesIncludePath.

Seems to fix issue in https://github.com/nuproj/nuproj/issues/261