### PR TITLE
Update GenerateNuSpec.GetContentFilesIncludePath and CreatePackage_SetContentFilesMetadata unit test

### DIFF
--- a/src/NuProj.Tasks/GenerateNuSpec.cs
+++ b/src/NuProj.Tasks/GenerateNuSpec.cs
@@ -275,7 +275,17 @@ namespace NuProj.Tasks
                 Log.LogError($"File '{taskItem.ItemSpec}' has unexpected PackageDirectory metadata. Expected '{PackageDirectory.ContentFiles}', actual '{packageDirectory}'.");
             }
 
-            return targetSubdirectory;
+            var source = taskItem.GetMetadata(Metadata.FileSource);
+            var filename = Path.GetFileName(source);
+
+            if (targetSubdirectory.EndsWith(filename))
+            {
+                return targetSubdirectory;
+            }
+            else
+            {
+                return Path.Combine(targetSubdirectory, filename);
+            }
         }
 
         private static IVersionSpec AggregateVersions(IVersionSpec aggregate, IVersionSpec next)

--- a/src/NuProj.Tasks/GenerateNuSpec.cs
+++ b/src/NuProj.Tasks/GenerateNuSpec.cs
@@ -275,8 +275,7 @@ namespace NuProj.Tasks
                 Log.LogError($"File '{taskItem.ItemSpec}' has unexpected PackageDirectory metadata. Expected '{PackageDirectory.ContentFiles}', actual '{packageDirectory}'.");
             }
 
-            var source = taskItem.GetMetadata(Metadata.FileSource);
-            return Path.Combine(targetSubdirectory, Path.GetFileName(source));
+            return targetSubdirectory;
         }
 
         private static IVersionSpec AggregateVersions(IVersionSpec aggregate, IVersionSpec next)

--- a/src/NuProj.Tests/CreatePackageTests.cs
+++ b/src/NuProj.Tests/CreatePackageTests.cs
@@ -50,7 +50,8 @@ namespace NuProj.Tests
             {
                 new ManifestContentFiles { Include=@"any\any\1x1.png", BuildAction="EmbeddedResource", CopyToOutput="false", Flatten="false"},
                 new ManifestContentFiles { Include=@"any\any\TextFile.txt", BuildAction="None", CopyToOutput="true", Flatten="false"},
-                new ManifestContentFiles { Include=@"cs\any\Class.cs.pp", CopyToOutput="false", Flatten="false"}
+                new ManifestContentFiles { Include=@"cs\any\Class.cs.pp", CopyToOutput="false", Flatten="false"},
+                new ManifestContentFiles { Include=@"cs\any\Class1.cs.pp", CopyToOutput="false", Flatten="false"}
             };
 
             Assert.Equal<ManifestContentFiles>(

--- a/src/NuProj.Tests/Scenarios/CreatePackage_SetContentFilesMetadata/Package/Class1.cs.pp
+++ b/src/NuProj.Tests/Scenarios/CreatePackage_SetContentFilesMetadata/Package/Class1.cs.pp
@@ -1,0 +1,6 @@
+﻿namespace $rootnamespace$
+{
+    public partial Class1
+    {
+    }
+}

--- a/src/NuProj.Tests/Scenarios/CreatePackage_SetContentFilesMetadata/Package/Package.nuproj
+++ b/src/NuProj.Tests/Scenarios/CreatePackage_SetContentFilesMetadata/Package/Package.nuproj
@@ -43,6 +43,9 @@
       <PackageCopyToOutput>True</PackageCopyToOutput>
     </ContentFile>
     <ContentFile Include="contentFiles\cs\any\Class.cs.pp" />
+    <ContentFile Include="Class1.cs.pp">
+      <Link>contentFiles\cs\any\Class1.cs.pp</Link>
+    </ContentFile>
     <Content Include="Readme.txt" />
   </ItemGroup>
   <Import Project="$(NuProjPath)\NuProj.targets" />


### PR DESCRIPTION
Don't duplicate the file name in return from GetContentFilesIncludePath by brute force EndsWith check.
Update the CreatePackage_SetContentFilesMetadata unit test to pack a Class1.cs.pp at a Link specified path.