### PR TITLE
Automatically set up NuProjPath

### DIFF
--- a/src/NuProj.Packages/NuProj.nuproj
+++ b/src/NuProj.Packages/NuProj.nuproj
@@ -42,6 +42,7 @@ There is also a Visual Studio extension which you find under http://bit.ly/NuPro
   </ItemGroup>
   
   <ItemGroup>
+    <Content Include="build\NuProj.props" />
     <Content Include="$(BasePath)raw\Additional\NuProj.props">
       <Link>tools\NuProj.props</Link>
     </Content>

--- a/src/NuProj.Packages/build/NuProj.props
+++ b/src/NuProj.Packages/build/NuProj.props
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <NuProjPath Condition="'$(NuProjPath)'==''">$(MSBuildThisFileDirectory)..\tools\</NuProjPath>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Fixes issue #277 

Though I got to thinking as I was manually testing it, that:

1. Without property support in nuget.exe to support _*.nuproj_ files (or many other files, for that matter), this really isn't that helpful, and
2. Who'd think to add the NuProj project to a _*.nuproj_ anyway?

So I suppose this is of limited to no value. But it was quick and easy, so it's up to you. Maybe there's another way to surface this file. It would be nice not to have to manually hard-code the path to the NuProj local package directory since updating the package wouldn't fix it.

If we can assume or otherwise detect the solution package cache directory, we could use the MSBuild property function to recursively find the path. Potentially slow, though.